### PR TITLE
Revert "Use goreleaser docker image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ executors:
     docker:
       - image: golangci/golangci-lint:v1.21.0
 
-  goreleaser:
-    docker:
-      - image: goreleaser/goreleaser:v0.126.0
-
 jobs:
   build:
     executor: golang
@@ -43,33 +39,36 @@ jobs:
       - run: make test
 
   crossbuild:
-    executor: goreleaser
+    executor: golang
 
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-crossbuild-cache
-      - run: goreleaser --skip-publish --rm-dist --snapshot
+            - v2-crossbuild-cache
+      - run: GO111MODULE=on go get github.com/goreleaser/goreleaser@v0.126.0
+      - run: git reset --hard
+      - run: make crossbuild
       - run: mkdir artifacts
       - run: mv dist/*.tar.gz dist/checksums.txt artifacts
       - store_artifacts:
           path: ./artifacts
       - save_cache:
-          key: v1-crossbuild-cache
+          key: v2-crossbuild-cache
           paths:
             - go/pkg
             - ~/.cache/go-build
 
   publish_release:
-    executor: goreleaser
+    executor: golang
 
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-crossbuild-cache
-      - run: goreleaser
+            - v2-crossbuild-cache
+      - run: GO111MODULE=on go get github.com/goreleaser/goreleaser@v0.126.0
+      - run: make release 
 
   check_repo_consistency:
     executor: golang


### PR DESCRIPTION
This reverts commit c5a16f73a58bb596ea2f1692c7eef25be57f884b.

Using the goreleaser image caused problems with file permissions.

While the file permissions looked right, the actual binaries were
impossible to execute.

Running `chmod 755` on the produced binaries did not change the
permissions shown by `ls -l` but somehow made them executable again.