### PR TITLE
Add test for langserver package

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -54,7 +54,7 @@ func (s *server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 		i := 0
 		for j, c := range name {
-			if 'a' <= c && c <= 'Z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
+			if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
 				i = j
 			} else {
 				break

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -544,12 +544,10 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	if err == nil {
 		panic("cannot shutdown server twice")
 	}
-	/*
-		// Left out until it does something else than calling os.Exit()
-		// Confirm Shutdown
-		err = s.Exit(context.Background())
-		if err != nil {
-			panic("Failed to initialize Server")
-		}
-	*/
+	// Left out until it does something else than calling os.Exit()
+	// Confirm Shutdown
+	err = s.Exit(context.Background())
+	if err != nil {
+		panic("Failed to initialize Server")
+	}
 } // nolint:wsl


### PR DESCRIPTION
This PR adds more unit tests for the `langserver` package.

The parts that interact with a Prometheus Server are still untested though.

Also, on typo that broke completion filtering for functions is fixed.