### PR TITLE
REST API: Don't ping Prometheus server on initialisation

### DIFF
--- a/cmd/promql-langserver/promql-langserver.go
+++ b/cmd/promql-langserver/promql-langserver.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	if config.RESTAPIPort != 0 {
 		fmt.Fprintln(os.Stderr, "REST API: Listening on port ", config.RESTAPIPort)
-		handler, err := rest.CreateAPIHandler(context.Background(), config.PrometheusURL)
+		handler, err := rest.CreateHandler(context.Background(), config.PrometheusURL)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -26,12 +26,10 @@ import (
 	"github.com/prometheus-community/promql-langserver/langserver"
 )
 
-// Create an API handler for the PromQL langserver REST API
+// CreateHandler creates an http.Handler for the PromQL langserver REST API.
 //
 // Expects the URL of a Prometheus server as the second argument.
-//
-// Will fail if the Prometheus server is not reachable.
-func CreateAPIHandler(ctx context.Context, prometheusURL string) (http.Handler, error) {
+func CreateHandler(ctx context.Context, prometheusURL string) (http.Handler, error) {
 	langserver, err := langserver.CreateHeadlessServer(ctx, prometheusURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the REST API is used inside Prometheus, the Prometheus server is
not yet up and running when the REST API is initialized. Creating the
API handler shouldn't fail in that case.

Signed-off-by: Tobias Guggenmos <tguggenm@redhat.com>