### PR TITLE
Fix theoretical race condition

### DIFF
--- a/langserver/cache/waitgroup.go
+++ b/langserver/cache/waitgroup.go
@@ -53,6 +53,9 @@ func (wg *waitGroup) Add(delta int32) {
 	}
 
 	if new == 0 {
+		wg.mu.Lock()
+		defer wg.mu.Unlock()
+
 		wg.cond.Broadcast()
 	}
 }


### PR DESCRIPTION
In certain edge cases it might have been possible, that a waitgroup.Wait() call would not actually return when it should.

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>