### PR TITLE
export metrics to prometheus

### DIFF
--- a/cmd/promql-langserver/promql-langserver.go
+++ b/cmd/promql-langserver/promql-langserver.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus-community/promql-langserver/langserver"
 	"github.com/prometheus-community/promql-langserver/rest"
 )
@@ -37,7 +39,7 @@ func main() {
 	}
 	if config.RESTAPIPort != 0 {
 		fmt.Fprintln(os.Stderr, "REST API: Listening on port ", config.RESTAPIPort)
-		handler, err := rest.CreateHandler(context.Background(), config.PrometheusURL)
+		handler, err := rest.CreateInstHandler(context.Background(), config.PrometheusURL, prometheus.NewRegistry())
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
see [issue 58](https://github.com/prometheus-community/promql-langserver/issues/58)
[InstrumentHandlerCounter](https://godoc.org/github.com/prometheus/client_golang/prometheus/promhttp#InstrumentHandlerCounter)) only supports two labels ( "code" and "method").