### PR TITLE
Fix nondeterministic test

### DIFF
--- a/langserver/cache/cache_test.go
+++ b/langserver/cache/cache_test.go
@@ -158,12 +158,12 @@ groups:
 		panic("expected exactly 4 queries for rules file got " + fmt.Sprint(len(queries)))
 	}
 
-	_, err = doc.getQuery(queries[0].Pos - 1)
+	_, err = doc.getQuery(97)
 	if err == nil {
 		panic("should have failed to get query")
 	}
 
-	_, err = doc.getQuery(queries[0].Pos)
+	_, err = doc.getQuery(98)
 	if err != nil {
 		panic("failed to get query: " + err.Error())
 	}


### PR DESCRIPTION
In one of the cache tests the test result depended on the order in which the queries were compiled.

This order is nondeterministic.

In case of a query with leading whitespace being compiled first, this led the test to expect a query where only whitespace that isn't part of the AST is found.

To fix this hardcoded positions are used instead.

Fixes #124

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>