### PR TITLE
Update copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Tobias Guggenmos tguggenm@redhat.com
+Copyright (c) 2019 The Prometheus Authors
 This project is licensed under the Apace 2.0 license
 It includes some parts from the gopls project that is licensed under BSD 
 style license. Both licenses can be found below.


### PR DESCRIPTION
Fixes #138 

I'll leave existing files as is for now, but new files should have "The Prometheus Authors" instead of my name as the copyright holder.