### PR TITLE
allow configuration by environment

### DIFF
--- a/cmd/promql-langserver/promql-langserver.go
+++ b/cmd/promql-langserver/promql-langserver.go
@@ -29,11 +29,11 @@ import (
 )
 
 func main() {
-	configFilePath := flag.String("config-file", "promql-lsp.yaml", "Configuration file for the language server")
+	configFilePath := flag.String("config-file", "", "Configuration file for the language server. If unset, the configuration will be retrieved from environment")
 
 	flag.Parse()
 
-	config, err := langserver.ParseConfigFile(*configFilePath)
+	config, err := langserver.ReadConfig(*configFilePath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error reading config file:", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/gorilla/websocket v1.4.2
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/common v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/common v0.10.0
 	github.com/prometheus/prometheus v1.8.2-0.20200316144747-012161d90d6a
 	github.com/rakyll/statik v0.1.7
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/prometheus/common v0.10.0
 	github.com/prometheus/prometheus v1.8.2-0.20200316144747-012161d90d6a
 	github.com/rakyll/statik v0.1.7
-	github.com/stretchr/testify v1.4.0
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 )

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Tobias Guggenmos
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -83,7 +83,7 @@ func (c *Config) Validate() error {
 // ReadConfig gets the GlobalConfig from a configFile (that is a path to the file)
 func ReadConfig(configFile string) (*Config, error) {
 	if len(configFile) == 0 {
-		fmt.Fprintln(os.Stderr, "Config file empty, configuration is reading from System environment")
+		fmt.Fprintln(os.Stderr, "No config file provided, configuration is reading from System environment")
 		return readConfigFromENV()
 	}
 	fmt.Fprintln(os.Stderr, "Configuration is reading from configuration file")

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"strconv"
 
 	"github.com/kelseyhightower/envconfig"
@@ -82,8 +83,10 @@ func (c *Config) Validate() error {
 // ReadConfig gets the GlobalConfig from a configFile (that is a path to the file)
 func ReadConfig(configFile string) (*Config, error) {
 	if len(configFile) == 0 {
+		fmt.Fprintln(os.Stderr, "Config file empty, configuration is reading from System environment")
 		return readConfigFromENV()
 	}
+	fmt.Fprintln(os.Stderr, "Configuration is reading from configuration file")
 	return readConfigFromYAML(configFile)
 }
 

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -17,7 +17,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/url"
+	"strconv"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/lsp/protocol"
 	"gopkg.in/yaml.v3"
 )
@@ -26,30 +29,78 @@ import (
 type Config struct {
 	RPCTrace      string `yaml:"rpc_trace"`
 	PrometheusURL string `yaml:"prometheus_url"`
-	RESTAPIPort   int    `yaml:"rest_api_port"`
+	RESTAPIPort   uint64 `yaml:"rest_api_port"`
 }
 
-// ParseConfig parses a yaml configuration.
-//
-// It expects the content of the configuration file as its argument.
-func ParseConfig(in []byte) (*Config, error) {
-	var config Config
-
-	err := yaml.Unmarshal(in, &config)
-
-	return &config, err
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	tmp := &Config{}
+	type plain Config
+	if err := unmarshal((*plain)(tmp)); err != nil {
+		return err
+	}
+	if err := tmp.Validate(); err != nil {
+		return err
+	}
+	*c = *tmp
+	return nil
 }
 
-// ParseConfigFile parses a yaml configuration file.
-//
-// It expects the path to a configuration file as its argument.
-func ParseConfigFile(path string) (*Config, error) {
-	data, err := ioutil.ReadFile(path)
+func (c *Config) UnmarshalENV() error {
+	prefix := "LANGSERVER"
+	conf := &struct {
+		RPCTrace      string
+		PrometheusURL string
+		// the envconfig lib is not able to convert an empty string to the value 0
+		// so we have to convert it manually
+		RESTAPIPort string
+	}{}
+	if err := envconfig.Process(prefix, conf); err != nil {
+		return err
+	}
+	if len(conf.RESTAPIPort) > 0 {
+		var parseError error
+		c.RESTAPIPort, parseError = strconv.ParseUint(conf.RESTAPIPort, 10, 64)
+		if parseError != nil {
+			return parseError
+		}
+	}
+	c.RPCTrace = conf.RPCTrace
+	c.PrometheusURL = conf.PrometheusURL
+	return c.Validate()
+}
+
+// Validate returns an error if the config is not valid
+func (c *Config) Validate() error {
+	if len(c.PrometheusURL) > 0 {
+		if _, err := url.Parse(c.PrometheusURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadConfig gets the GlobalConfig from a configFile (that is a path to the file)
+func ReadConfig(configFile string) (*Config, error) {
+	if len(configFile) == 0 {
+		return readConfigFromENV()
+	}
+	return readConfigFromYAML(configFile)
+}
+
+func readConfigFromYAML(configFile string) (*Config, error) {
+	b, err := ioutil.ReadFile(configFile) //nolint
 	if err != nil {
 		return nil, err
 	}
+	res := new(Config)
+	err = yaml.Unmarshal(b, res)
+	return res, err
+}
 
-	return ParseConfig(data)
+func readConfigFromENV() (*Config, error) {
+	res := new(Config)
+	err := res.UnmarshalENV()
+	return res, err
 }
 
 // DidChangeConfiguration is required by the protocol.Server interface

--- a/langserver/config_test.go
+++ b/langserver/config_test.go
@@ -46,8 +46,10 @@ func TestUnmarshalENV(t *testing.T) {
 		},
 	}
 	for _, testSuite := range testSuites {
+		// nolint
 		t.Run(testSuite.title, func(t *testing.T) {
 			os.Clearenv()
+			// nolint
 			for k, v := range testSuite.variables {
 				os.Setenv(k, v)
 			}
@@ -56,5 +58,4 @@ func TestUnmarshalENV(t *testing.T) {
 			assert.Equal(t, testSuite.expected, conf)
 		})
 	}
-
 }

--- a/langserver/config_test.go
+++ b/langserver/config_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package langserver
 
 import (

--- a/langserver/config_test.go
+++ b/langserver/config_test.go
@@ -1,0 +1,47 @@
+package langserver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalENV(t *testing.T) {
+	testSuites := []struct {
+		title     string
+		variables map[string]string
+		expected  *Config
+	}{
+		{
+			title:     "empty config",
+			variables: map[string]string{},
+			expected:  &Config{},
+		},
+		{
+			title: "full config",
+			variables: map[string]string{
+				"LANGSERVER_RPCTRACE":      "text",
+				"LANGSERVER_PROMETHEUSURL": "http://localhost:9090",
+				"LANGSERVER_RESTAPIPORT":   "8080",
+			},
+			expected: &Config{
+				RPCTrace:      "text",
+				PrometheusURL: "http://localhost:9090",
+				RESTAPIPort:   8080,
+			},
+		},
+	}
+	for _, testSuite := range testSuites {
+		t.Run(testSuite.title, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range testSuite.variables {
+				os.Setenv(k, v)
+			}
+			conf, err := ReadConfig("")
+			assert.Nil(t, err)
+			assert.Equal(t, testSuite.expected, conf)
+		})
+	}
+
+}

--- a/langserver/config_test.go
+++ b/langserver/config_test.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 func TestUnmarshalENV(t *testing.T) {
@@ -54,8 +54,8 @@ func TestUnmarshalENV(t *testing.T) {
 				os.Setenv(k, v)
 			}
 			conf, err := ReadConfig("")
-			assert.Nil(t, err)
-			assert.Equal(t, testSuite.expected, conf)
+			testutil.Ok(t, err)
+			testutil.Equals(t, testSuite.expected, conf)
 		})
 	}
 }


### PR DESCRIPTION
In order to simplify the set up of the future docker image, the langueServer should be able to retrieve the configuration using the system environment.

It's a first step to resolve the issue #146 