### PR TITLE
Add Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+## Prometheus Community Code of Conduct
+
+Prometheus follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
This code of conduct is simply copied from `prometheus/prometheus`.

I assume the same Code of Conduct applies here anyway, so this PR basically just adds clarification.

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>