### PR TITLE
Code lenses for evalating PromQL queries

### DIFF
--- a/langserver/cache/cache_test.go
+++ b/langserver/cache/cache_test.go
@@ -234,7 +234,7 @@ groups:
 					Line:      9.0,
 					Character: 0.0,
 				},
-				End: endOfLine(protocol.Position{
+				End: EndOfLine(protocol.Position{
 					Line:      10.0,
 					Character: 0.1,
 				}),

--- a/langserver/cache/position.go
+++ b/langserver/cache/position.go
@@ -126,8 +126,8 @@ func (d *DocumentHandle) yamlPositionToTokenPos(line int, column int, lineOffset
 	}
 }
 
-// endOfLine returns the end of the Line of the given protocol.Position.
-func endOfLine(p protocol.Position) protocol.Position {
+// EndOfLine returns the end of the Line of the given protocol.Position.
+func EndOfLine(p protocol.Position) protocol.Position {
 	return protocol.Position{
 		Line:      p.Line + 1,
 		Character: 0,

--- a/langserver/codeLens.go
+++ b/langserver/codeLens.go
@@ -1,0 +1,28 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.  // You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package langserver
+
+import (
+	"context"
+
+	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/lsp/protocol"
+)
+
+// CodeLens is required by the protocol.Server interface.
+func (s *server) CodeLens(_ context.Context, _ *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
+	// As of version 0.4.0 of gopls it is not possible to instruct the language
+	// client to stop asking for Code Lenses and Document Links. To prevent
+	// VS Code from showing error messages, this feature is implemented by
+	// returning empty values.
+	return nil, nil
+}

--- a/langserver/codeLens.go
+++ b/langserver/codeLens.go
@@ -20,9 +20,6 @@ import (
 
 // CodeLens is required by the protocol.Server interface.
 func (s *server) CodeLens(_ context.Context, _ *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
-	// As of version 0.4.0 of gopls it is not possible to instruct the language
-	// client to stop asking for Code Lenses and Document Links. To prevent
-	// VS Code from showing error messages, this feature is implemented by
-	// returning empty values.
+
 	return nil, nil
 }

--- a/langserver/general.go
+++ b/langserver/general.go
@@ -23,7 +23,7 @@ import (
 
 // Initialize handles a call from the client to initialize the server.
 // Required by the protocol.Server interface.
-func (s *server) Initialize(_ context.Context, _ *protocol.ParamInitialize) (*protocol.InitializeResult, error) {
+func (s *server) Initialize(_ context.Context, paramInitialize *protocol.ParamInitialize) (*protocol.InitializeResult, error) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
@@ -34,6 +34,8 @@ func (s *server) Initialize(_ context.Context, _ *protocol.ParamInitialize) (*pr
 	s.state = serverInitializing
 
 	s.cache.Init()
+
+	s.initializeParams = paramInitialize.InitializeParams
 
 	return &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -17,10 +17,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go/token"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -133,30 +131,6 @@ func (s *server) nodeToDocMarkdown(ctx context.Context, location *cache.Location
 
 	if expr, ok := location.Node.(promql.Expr); ok {
 		_, err := ret.WriteString(fmt.Sprintf("\n\n__PromQL Type:__ %s\n\n", promql.DocumentedType(expr.Type())))
-		if err != nil {
-			return ""
-		}
-	}
-
-	promURL := s.metadataService.GetURL()
-
-	if promURL != "" && !s.headless {
-		loc := *location
-
-		loc.Node = loc.Query.Ast
-
-		qText, err := location.Doc.GetSubstring(loc.Query.Pos+token.Pos(loc.Node.PositionRange().Start), loc.Query.Pos+token.Pos(loc.Node.PositionRange().End))
-		if err != nil {
-			return ""
-		}
-
-		qTextEncoded := url.QueryEscape(qText)
-
-		target := fmt.Sprint(promURL, "/graph?g0.expr=", qTextEncoded)
-
-		linkText := fmt.Sprintf("---\n[evaluate query](%s)\n\n", target)
-
-		_, err = ret.WriteString(linkText)
 		if err != nil {
 			return ""
 		}

--- a/langserver/notImplemented.go
+++ b/langserver/notImplemented.go
@@ -141,15 +141,6 @@ func (s *server) Symbol(_ context.Context, _ *protocol.WorkspaceSymbolParams) ([
 	return nil, notImplemented("Symbol")
 }
 
-// CodeLens is required by the protocol.Server interface.
-func (s *server) CodeLens(_ context.Context, _ *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
-	// As of version 0.4.0 of gopls it is not possible to instruct the language
-	// client to stop asking for Code Lenses and Document Links. To prevent
-	// VS Code from showing error messages, this feature is implemented by
-	// returning empty values.
-	return nil, nil
-}
-
 // ResolveCodeLens is required by the protocol.Server interface.
 func (s *server) ResolveCodeLens(_ context.Context, _ *protocol.CodeLens) (*protocol.CodeLens, error) {
 	return nil, notImplemented("ResolveCodeLens")

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -49,8 +49,9 @@ type server struct {
 	Conn   *jsonrpc2.Conn
 	client protocol.Client
 
-	state   serverState
-	stateMu sync.Mutex
+	state            serverState
+	stateMu          sync.Mutex
+	initializeParams protocol.InitializeParams
 
 	cache cache.DocumentCache
 


### PR DESCRIPTION
Fixes #161 .

![image](https://user-images.githubusercontent.com/15368509/84914083-8120ba00-b0bb-11ea-9e8b-c0a8320e99b6.png)

This also requires some work on the VS Code extension site: https://github.com/redhat-developer/vscode-promql/pull/75

However at the moment that doesn't work properly, because URL handling in VS Code is pretty broken.

microsoft/vscode#85930
microsoft/vscode#83645
