### PR TITLE
returned an error each time something bad occurred.

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -34,7 +34,7 @@ import (
 func (s *server) Completion(ctx context.Context, params *protocol.CompletionParams) (ret *protocol.CompletionList, err error) {
 	location, err := s.cache.Find(&params.TextDocumentPositionParams)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	ret = &protocol.CompletionList{}

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -21,13 +21,13 @@ import (
 )
 
 // Definition is required by the protocol.Server interface.
-func (s *server) Definition(ctx context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
+func (s *server) Definition(_ context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
 	location, err := s.cache.Find(&params.TextDocumentPositionParams)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
-	defs := []protocol.Location{}
+	var defs []protocol.Location
 
 	switch n := location.Node.(type) { // nolint: gocritic
 	case *promql.VectorSelector:

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -50,13 +50,13 @@ func initializeFunctionDocumentation() http.FileSystem {
 func (s *server) Hover(ctx context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
 	location, err := s.cache.Find(&params.TextDocumentPositionParams)
 	if err != nil || location.Node == nil {
-		return nil, nil
+		return nil, err
 	}
 
 	markdown := s.nodeToDocMarkdown(ctx, location)
 	hoverRange, err := getEditRange(location, "")
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	return &protocol.Hover{

--- a/langserver/signature.go
+++ b/langserver/signature.go
@@ -22,20 +22,20 @@ import (
 )
 
 // SignatureHelp is required by the protocol.Server interface.
-func (s *server) SignatureHelp(ctx context.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
+func (s *server) SignatureHelp(_ context.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
 	location, err := s.cache.Find(&params.TextDocumentPositionParams)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	call, ok := location.Node.(*promql.Call)
 	if !ok {
-		return nil, nil
+		return nil, errors.New("no node find for the given query")
 	}
 
 	signature, err := getSignature(call.Func.Name)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	activeParameter := 0.


### PR DESCRIPTION
fix #189 

now it returns an http error 500.

I suppose we should type the error coming from the cache to associate them to a better HTTP error code