### PR TITLE
Add missing nil pointer check

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -140,7 +140,11 @@ func (a *API) diagnostics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := diagnostics.Diagnostics
+	items := []protocol.Diagnostic{}
+	if diagnostics != nil {
+		items = diagnostics.Diagnostics
+	}
+
 	limit := requestData.Limit
 	if limit != nil && uint64(len(items)) > *limit {
 		items = items[:*limit]
@@ -204,7 +208,10 @@ func (a *API) completion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := completion.Items
+	items := []protocol.CompletionItem{}
+	if completion != nil {
+		items = completion.Items
+	}
 	limit := requestData.Limit
 	if limit != nil && uint64(len(items)) > *limit {
 		items = items[:*limit]


### PR DESCRIPTION
Fixes #189.

This fixes some unchecked pointer accesses in the rest package.

Independently of how errors are handled, these checks should be in place.

Proper error handling as discussed in #189 and #190 can happen separately.

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>