### PR TITLE
Suggest label name and values based on current query vector selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1
 	github.com/rakyll/statik v0.1.7
 	github.com/sahilm/fuzzy v0.1.0
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,7 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1 h1:Oh/bmW9DXCbMeAZbxMmt2wuY6Q4cD0IIbR6vJP3kdHg=
 github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1/go.mod h1:S5n0C6tSgdnwWshBUceRx5G1OsjLv/EeZ9t3wIfEtsY=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -688,6 +689,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -15,222 +15,231 @@ package langserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus-community/promql-langserver/config"
 	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/jsonrpc2"
 	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/lsp/protocol"
+	"github.com/prometheus-community/promql-langserver/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNotImplemented checks whether unimplemented functions return the approbiate Error.
-func TestNotImplemented(*testing.T) { // nolint: gocognit, funlen, gocyclo
+func TestNotImplemented(t *testing.T) { // nolint: gocognit, funlen, gocyclo
 	s := &server{}
 
 	err := s.DidChangeWorkspaceFolders(context.Background(), &protocol.DidChangeWorkspaceFoldersParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.DidSave(context.Background(), &protocol.DidSaveTextDocumentParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.WillSave(context.Background(), &protocol.WillSaveTextDocumentParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.DidChangeWatchedFiles(context.Background(), &protocol.DidChangeWatchedFilesParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.Progress(context.Background(), &protocol.ProgressParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.SelectionRange(context.Background(), &protocol.SelectionRangeParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.SetTraceNotification(context.Background(), &protocol.SetTraceParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.LogTraceNotification(context.Background(), &protocol.LogTraceParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Implementation(context.Background(), &protocol.ImplementationParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.TypeDefinition(context.Background(), &protocol.TypeDefinitionParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentColor(context.Background(), &protocol.DocumentColorParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ColorPresentation(context.Background(), &protocol.ColorPresentationParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.FoldingRange(context.Background(), &protocol.FoldingRangeParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.NonstandardRequest(context.Background(), "", nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Declaration(context.Background(), &protocol.DeclarationParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.WillSaveWaitUntil(context.Background(), &protocol.WillSaveTextDocumentParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Resolve(context.Background(), &protocol.CompletionItem{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Definition(context.Background(), &protocol.DefinitionParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.References(context.Background(), &protocol.ReferenceParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentHighlight(context.Background(), &protocol.DocumentHighlightParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentSymbol(context.Background(), &protocol.DocumentSymbolParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.CodeAction(context.Background(), &protocol.CodeActionParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Symbol(context.Background(), &protocol.WorkspaceSymbolParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.CodeLens(context.Background(), &protocol.CodeLensParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ResolveCodeLens(context.Background(), &protocol.CodeLens{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Formatting(context.Background(), &protocol.DocumentFormattingParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.RangeFormatting(context.Background(), &protocol.DocumentRangeFormattingParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.OnTypeFormatting(context.Background(), &protocol.DocumentOnTypeFormattingParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Rename(context.Background(), &protocol.RenameParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.PrepareRename(context.Background(), &protocol.PrepareRenameParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentLink(context.Background(), &protocol.DocumentLinkParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ResolveDocumentLink(context.Background(), &protocol.DocumentLink{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{})
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.IncomingCalls(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.OutgoingCalls(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.PrepareCallHierarchy(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.SemanticTokens(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.SemanticTokensEdits(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.SemanticTokensRange(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.WorkDoneProgressCancel(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.WorkDoneProgressCreate(context.Background(), nil)
 	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
-		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
+		require.Fail(t, "Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 }
 
@@ -266,50 +275,45 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	var stream jsonrpc2.Stream = &dummyStream{}
 	stream = jSONLogStream(stream, &dummyWriter{})
 	_, server := ServerFromStream(context.Background(), stream, &config.Config{LogFormat: config.TextFormat})
-	s := server.server
+	s := mustServerTest(t, server.server)
 
 	// Initialize Server
-	_, err := s.Initialize(context.Background(), &protocol.ParamInitialize{})
+	_, err := s.server.Initialize(context.Background(), &protocol.ParamInitialize{})
 	if err != nil {
-		panic("Failed to initialize Server")
+		require.Fail(t, "Failed to initialize Server")
 	}
 
-	_, err = s.Initialize(context.Background(), &protocol.ParamInitialize{})
+	_, err = s.server.Initialize(context.Background(), &protocol.ParamInitialize{})
 	if err == nil {
-		panic("cannot initialize server twice")
+		require.Fail(t, "cannot initialize server twice")
 	}
 	// Confirm Initialisation
-	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
+	err = s.server.Initialized(context.Background(), &protocol.InitializedParams{})
 	if err != nil {
-		panic("Failed to initialize Server")
+		require.Fail(t, "Failed to initialize Server")
 	}
 
-	err = s.Initialized(context.Background(), &protocol.InitializedParams{})
+	err = s.server.Initialized(context.Background(), &protocol.InitializedParams{})
 	if err == nil {
-		panic("cannot confirm server initialisation twice")
+		require.Fail(t, "cannot confirm server initialisation twice")
 	}
 
 	// Add a document to the server
-	err = s.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+	err = s.server.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
 		TextDocument: protocol.TextDocumentItem{
-			URI:        "test.promql",
+			URI:        s.doc.DocumentURI(),
+			Version:    s.doc.NextVersion(),
 			LanguageID: "promql",
-			Version:    0,
 			Text:       "",
 		},
 	})
 	if err != nil {
-		panic("Failed to open document")
+		require.Fail(t, "Failed to open document")
 	}
 
 	// Apply a Full Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 2,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range:       nil,
@@ -319,14 +323,12 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 	})
 	if err != nil {
-		panic("Failed to apply full change to document")
+		require.Fail(t, "Failed to apply full change to document")
 	}
 
-	hover, err := s.Hover(context.Background(), &protocol.HoverParams{
+	hover, err := s.server.Hover(context.Background(), &protocol.HoverParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0.0,
 				Character: 1.0,
@@ -335,22 +337,17 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	})
 
 	if err != nil {
-		panic("Failed to get hovertext")
+		require.Fail(t, "Failed to get hovertext")
 	}
 
 	if hover == nil || strings.Contains("sum", hover.Contents.Value) {
 		fmt.Println(hover)
-		panic("unexpected or no hovertext")
+		require.Fail(t, "unexpected or no hovertext")
 	}
 
 	// Apply a Full Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 3,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range:       nil,
@@ -360,14 +357,12 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 	})
 	if err != nil {
-		panic("Failed to apply full change to document")
+		require.Fail(t, "Failed to apply full change to document")
 	}
 
-	hover, err = s.Hover(context.Background(), &protocol.HoverParams{
+	hover, err = s.server.Hover(context.Background(), &protocol.HoverParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0.0,
 				Character: 1.0,
@@ -376,21 +371,16 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	})
 
 	if err != nil {
-		panic("Failed to get hovertext")
+		require.Fail(t, "Failed to get hovertext")
 	}
 
 	if hover == nil || strings.Contains("metric_name", hover.Contents.Value) {
 		fmt.Println(hover)
-		panic("unexpected or no hovertext")
+		require.Fail(t, "unexpected or no hovertext")
 	}
 	// Apply a partial Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 4,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range: &protocol.Range{
@@ -413,23 +403,18 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	}
 
 	// Wait for diagnostics
-	doc, err := s.cache.GetDocument("test.promql")
+	doc, err := s.server.cache.GetDocument("test.promql")
 	if err != nil {
-		panic("Failed to get document")
+		require.Fail(t, "Failed to get document")
 	}
 
 	if diagnostics, err := doc.GetDiagnostics(); err != nil && len(diagnostics) != 0 {
-		panic("expected nonempty diagnostics")
+		require.Fail(t, "expected nonempty diagnostics")
 	}
 
 	// Apply a partial Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 5,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range: &protocol.Range{
@@ -452,20 +437,20 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	}
 
 	// Wait for diagnostics
-	doc, err = s.cache.GetDocument("test.promql")
+	doc, err = s.server.cache.GetDocument("test.promql")
 	if err != nil {
-		panic("Failed to get document")
+		require.Fail(t, "Failed to get document")
 	}
 
 	if diagnostics, err := doc.GetDiagnostics(); err != nil && len(diagnostics) != 0 {
-		panic("expected empty diagnostics")
+		require.Fail(t, "expected empty diagnostics")
 	}
 
 	var content string
 
 	content, err = doc.GetContent()
 	if err != nil {
-		panic("failed to get document content")
+		require.Fail(t, "failed to get document content")
 	}
 
 	if content != "rate(metric)" {
@@ -473,13 +458,8 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	}
 
 	// Apply a Full Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 6,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range:       nil,
@@ -489,14 +469,12 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 	})
 	if err != nil {
-		panic("Failed to apply full change to document")
+		require.Fail(t, "Failed to apply full change to document")
 	}
 
-	completion, err := s.Completion(context.Background(), &protocol.CompletionParams{
+	completion, err := s.server.Completion(context.Background(), &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0.0,
 				Character: 1.0,
@@ -506,17 +484,12 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 
 	if err != nil || completion == nil || len(completion.Items) == 0 || completion.Items[0].Label != "rate" {
 		fmt.Println(completion)
-		panic("Failed to get completion")
+		require.Fail(t, "Failed to get completion")
 	}
 
 	// Apply a Full Change to the document
-	err = s.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			Version: 7,
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
-		},
+	err = s.server.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: s.doc.NextVersionID(),
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
 				Range:       nil,
@@ -526,14 +499,12 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 	})
 	if err != nil {
-		panic("Failed to apply full change to document")
+		require.Fail(t, "Failed to apply full change to document")
 	}
 
-	completion, err = s.Completion(context.Background(), &protocol.CompletionParams{
+	completion, err = s.server.Completion(context.Background(), &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0.0,
 				Character: 1.0,
@@ -543,52 +514,51 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 
 	if err != nil || completion == nil || len(completion.Items) == 0 || completion.Items[0].Label != "rate" {
 		fmt.Println(completion)
-		panic("Failed to get completion")
+		require.Fail(t, "Failed to get completion")
 	}
 
 	// Close a document
-	err = s.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
+	err = s.server.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
 		TextDocument: protocol.TextDocumentIdentifier{
-			URI: "test.promql",
+			URI: s.doc.DocumentURI(),
 		},
 	})
 	if err != nil {
-		panic("Failed to close document")
+		require.Fail(t, "Failed to close document")
 	}
 
-	_, err = s.cache.GetDocument("test.promql")
+	_, err = s.server.cache.GetDocument("test.promql")
 	if err == nil {
-		panic("getting a closed document should have failed")
+		require.Fail(t, "getting a closed document should have failed")
 	}
 
 	// Close a document twice
-	err = s.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
+	err = s.server.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
 		TextDocument: protocol.TextDocumentIdentifier{
-			URI: "test.promql",
+			URI: s.doc.DocumentURI(),
 		},
 	})
 	if err == nil {
-		panic("should have failed to close document")
+		require.Fail(t, "should have failed to close document")
 	}
 
 	// Reopen a closed document
-	err = s.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+	s.doc.ResetVersion()
+	err = s.server.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
 		TextDocument: protocol.TextDocumentItem{
-			URI:        "test.promql",
+			URI:        s.doc.DocumentURI(),
+			Version:    s.doc.NextVersion(),
 			LanguageID: "promql",
-			Version:    0,
 			Text:       "abs()",
 		},
 	})
 	if err != nil {
-		panic("Failed to reopen document")
+		require.Fail(t, "Failed to reopen document")
 	}
 
-	signature, err := s.SignatureHelp(context.Background(), &protocol.SignatureHelpParams{
+	signature, err := s.server.SignatureHelp(context.Background(), &protocol.SignatureHelpParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      1.0,
 				Character: 0.0,
@@ -597,19 +567,17 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	})
 
 	if err != nil {
-		panic("Failed to get signature")
+		require.Fail(t, "Failed to get signature")
 	}
 
 	if signature != nil && len(signature.Signatures) != 0 {
 		fmt.Println(signature)
-		panic("Wrong number of signatures returned")
+		require.Fail(t, "Wrong number of signatures returned")
 	}
 
-	signature, err = s.SignatureHelp(context.Background(), &protocol.SignatureHelpParams{
+	signature, err = s.server.SignatureHelp(context.Background(), &protocol.SignatureHelpParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0,
 				Character: 4,
@@ -618,19 +586,17 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	})
 
 	if err != nil {
-		panic("Failed to get signature")
+		require.Fail(t, "Failed to get signature")
 	}
 
 	if signature == nil || len(signature.Signatures) != 1 {
 		fmt.Println(signature.Signatures)
-		panic("Wrong number of signatures returned")
+		require.Fail(t, "Wrong number of signatures returned")
 	}
 
-	hover, err = s.Hover(context.Background(), &protocol.HoverParams{
+	hover, err = s.server.Hover(context.Background(), &protocol.HoverParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{
-				URI: "test.promql",
-			},
+			TextDocument: s.doc.ID(),
 			Position: protocol.Position{
 				Line:      0.0,
 				Character: 1.0,
@@ -639,28 +605,391 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 	})
 
 	if err != nil {
-		panic("Failed to get hovertext")
+		require.Fail(t, "Failed to get hovertext")
 	}
 
 	if hover == nil || strings.Contains("abs", hover.Contents.Value) {
 		fmt.Println(hover)
-		panic("unexpected or no hovertext")
+		require.Fail(t, "unexpected or no hovertext")
 	}
+
+	// Run completion metadata tests.
+	t.Run("completion label name: sum(metric_name{})", func(t *testing.T) {
+		// Apply a Full Change to the document.
+		err := s.server.DidChange(context.Background(),
+			&protocol.DidChangeTextDocumentParams{
+				TextDocument: s.doc.NextVersionID(),
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{
+					{
+						Range:       nil,
+						RangeLength: 0,
+						Text:        "sum(metric_name{})",
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to apply full change to document")
+
+		// Simulate completions for metric_name.
+		metaServer := s.SetupTestMetaServer()
+		defer metaServer.TearDown()
+
+		metaServer.HandleFunc("/api/v1/series",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, []string{"metric_name"}, r.Form["match[]"])
+
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "success",
+					"data": []interface{}{
+						map[string]string{
+							"foo_name": "foo_value",
+							"bar_name": "bar_value",
+						},
+					},
+				})
+			})
+
+		completion, err := s.server.Completion(context.Background(),
+			&protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: s.doc.ID(),
+					Position: protocol.Position{
+						Line:      0.0,
+						Character: 16.0,
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to get completion")
+		expected := []string{
+			"bar_name",
+			"foo_name",
+		}
+		actual := completionValuesSorted(t, completion)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("completion label name: sum(metric_name{foo_name=\"foo_value\",})", func(t *testing.T) {
+		// Apply a Full Change to the document.
+		err := s.server.DidChange(context.Background(),
+			&protocol.DidChangeTextDocumentParams{
+				TextDocument: s.doc.NextVersionID(),
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{
+					{
+						Range:       nil,
+						RangeLength: 0,
+						Text:        "sum(metric_name{foo_name=\"foo_value\",})",
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to apply full change to document")
+
+		// Simulate completions for metric_name.
+		metaServer := s.SetupTestMetaServer()
+		defer metaServer.TearDown()
+
+		metaServer.HandleFunc("/api/v1/series",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, []string{"metric_name{foo_name=\"foo_value\"}"}, r.Form["match[]"])
+
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "success",
+					"data": []interface{}{
+						map[string]string{
+							"foo_name": "foo_value",
+							"bar_name": "bar_value",
+						},
+						map[string]string{
+							"foo_name": "foo_value",
+							"baz_name": "baz_value",
+						},
+					},
+				})
+			})
+
+		completion, err := s.server.Completion(context.Background(),
+			&protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: s.doc.ID(),
+					Position: protocol.Position{
+						Line:      0.0,
+						Character: 37.0,
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to get completion")
+		expected := []string{
+			"bar_name",
+			"baz_name",
+		}
+		actual := completionValuesSorted(t, completion)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("completion label name: sum(metric_name{foo_name=\"foo_value\",baz_name=\"\"})", func(t *testing.T) {
+		// Apply a Full Change to the document.
+		err := s.server.DidChange(context.Background(),
+			&protocol.DidChangeTextDocumentParams{
+				TextDocument: s.doc.NextVersionID(),
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{
+					{
+						Range:       nil,
+						RangeLength: 0,
+						Text:        "sum(metric_name{foo_name=\"foo_value\",baz_name=\"\"})",
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to apply full change to document")
+
+		// Simulate completions for metric_name.
+		metaServer := s.SetupTestMetaServer()
+		defer metaServer.TearDown()
+
+		metaServer.HandleFunc("/api/v1/series",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, []string{"metric_name{foo_name=\"foo_value\"}"}, r.Form["match[]"])
+
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "success",
+					"data": []interface{}{
+						map[string]string{
+							"foo_name": "foo_value",
+							"bar_name": "bar_value",
+						},
+						map[string]string{
+							"foo_name": "foo_value",
+							"baz_name": "baz_value",
+						},
+						map[string]string{
+							"foo_name": "foo_value",
+							"baz_name": "baz_value2",
+						},
+					},
+				})
+			})
+
+		completion, err := s.server.Completion(context.Background(),
+			&protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: s.doc.ID(),
+					Position: protocol.Position{
+						Line:      0.0,
+						Character: 48.0,
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to get completion")
+		expected := []string{
+			"\"baz_value\"",
+			"\"baz_value2\"",
+		}
+		actual := completionValuesSorted(t, completion)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("completion label name: sum(metric_name{foo_name=\"foo_value\"}) by ()", func(t *testing.T) {
+		// Apply a Full Change to the document.
+		err := s.server.DidChange(context.Background(),
+			&protocol.DidChangeTextDocumentParams{
+				TextDocument: s.doc.NextVersionID(),
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{
+					{
+						Range:       nil,
+						RangeLength: 0,
+						Text:        "sum(metric_name{foo_name=\"foo_value\"}) by ()",
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to apply full change to document")
+
+		// Simulate completions for metric_name.
+		metaServer := s.SetupTestMetaServer()
+		defer metaServer.TearDown()
+
+		metaServer.HandleFunc("/api/v1/series",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, []string{"metric_name{foo_name=\"foo_value\"}"}, r.Form["match[]"])
+
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "success",
+					"data": []interface{}{
+						map[string]string{
+							"foo_name": "foo_value",
+							"bar_name": "bar_value",
+						},
+						map[string]string{
+							"foo_name": "foo_value",
+							"baz_name": "baz_value",
+						},
+						map[string]string{
+							"foo_name": "foo_value",
+							"baz_name": "baz_value2",
+						},
+					},
+				})
+			})
+
+		completion, err := s.server.Completion(context.Background(),
+			&protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: s.doc.ID(),
+					Position: protocol.Position{
+						Line:      0.0,
+						Character: 43.0,
+					},
+				},
+			})
+		require.NoError(t, err, "Failed to get completion")
+		expected := []string{
+			"bar_name",
+			"baz_name",
+		}
+		actual := completionValuesSorted(t, completion)
+		require.Equal(t, expected, actual)
+	})
 
 	// Shutdown Server
-	err = s.Shutdown(context.Background())
+	err = s.server.Shutdown(context.Background())
 	if err != nil {
-		panic("Failed to initialize Server")
+		require.Fail(t, "Failed to initialize Server")
 	}
 
-	err = s.Shutdown(context.Background())
+	err = s.server.Shutdown(context.Background())
 	if err == nil {
-		panic("cannot shutdown server twice")
+		require.Fail(t, "cannot shutdown server twice")
 	}
 	// Left out until it does something else than calling os.Exit()
 	// Confirm Shutdown
-	err = s.Exit(context.Background())
+	err = s.server.Exit(context.Background())
 	if err != nil {
-		panic("Failed to initialize Server")
+		require.Fail(t, "Failed to initialize Server")
 	}
+}
+
+func completionValuesSorted(
+	t *testing.T,
+	completions *protocol.CompletionList,
+) []string {
+	require.NotNil(t, completions)
+	results := make([]string, 0, len(completions.Items))
+	for _, item := range completions.Items {
+		results = append(results, item.Label)
+	}
+	sort.Strings(results)
+	return results
+}
+
+type serverTest struct {
+	t      *testing.T
+	server *server
+	doc    *testDocument
+}
+
+func mustServerTest(t *testing.T, server *server) *serverTest {
+	s := &serverTest{
+		t:      t,
+		server: server,
+		doc: &testDocument{
+			name:    "test.promql",
+			version: 0,
+		},
+	}
+	s.resetMetadataService()
+	return s
+}
+
+func (t *serverTest) resetMetadataService() {
+	// Default meta service.
+	svc, err := prometheus.NewClient("", 5*time.Minute)
+	require.NoError(t.t, err, "Failed to initialize metadata service")
+
+	// Reset the metadata service on the server.
+	t.server.metadataService = svc
+}
+
+func (t *serverTest) SetupTestMetaServer() *testMetadataServer {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/status/buildinfo",
+		func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(&prometheus.BuildInfoResponse{
+				Status: "up",
+				Data: prometheus.BuildInfoData{
+					Version:   prometheus.RequiredVersion.String(),
+					Revision:  "HEAD",
+					Branch:    "master",
+					BuildUser: "prometheus",
+					BuildDate: time.Now().String(),
+					GoVersion: runtime.Version(),
+				},
+			})
+		})
+
+	server := httptest.NewServer(mux)
+
+	// Create new metadata service.
+	svc, err := prometheus.NewClient(server.URL, 5*time.Minute)
+	require.NoError(t.t, err, "Failed to initialize fake metadata service")
+
+	// Reset the metadata service on the server.
+	t.server.metadataService = svc
+
+	return &testMetadataServer{
+		serverTest: t,
+		mux:        mux,
+		server:     server,
+	}
+}
+
+type testDocument struct {
+	name    string
+	version int
+}
+
+func (d *testDocument) ID() protocol.TextDocumentIdentifier {
+	return protocol.TextDocumentIdentifier{
+		URI: d.DocumentURI(),
+	}
+}
+
+func (d *testDocument) NextVersionID() protocol.VersionedTextDocumentIdentifier {
+	return protocol.VersionedTextDocumentIdentifier{
+		Version:                d.NextVersion(),
+		TextDocumentIdentifier: d.ID(),
+	}
+}
+
+func (d *testDocument) DocumentURI() protocol.DocumentURI {
+	return protocol.DocumentURI(d.name)
+}
+
+func (d *testDocument) NextVersion() float64 {
+	v := d.version
+	d.version++
+	return float64(v)
+}
+
+func (d *testDocument) ResetVersion() {
+	d.version = 0
+}
+
+type testMetadataServer struct {
+	serverTest *serverTest
+	mux        *http.ServeMux
+	server     *httptest.Server
+}
+
+func (s *testMetadataServer) HandleFunc(
+	pattern string,
+	handler func(http.ResponseWriter, *http.Request),
+) {
+	s.mux.HandleFunc(pattern, handler)
+}
+
+func (s *testMetadataServer) TearDown() {
+	// Close server.
+	s.server.Close()
+	// Reset metadata service.
+	s.serverTest.resetMetadataService()
 }

--- a/prometheus/compatible.go
+++ b/prometheus/compatible.go
@@ -49,15 +49,15 @@ func (c *compatibleHTTPClient) AllMetricMetadata(ctx context.Context) (map[strin
 
 func (c *compatibleHTTPClient) LabelNames(
 	ctx context.Context,
-	selection model.LabelSet,
+	currLabelsSelected model.LabelSet,
 ) ([]string, error) {
-	if selection == nil {
+	if currLabelsSelected == nil {
 		names, _, err := c.prometheusClient.LabelNames(ctx, time.Now().Add(-1*c.lookbackInterval), time.Now())
 		return names, err
 	}
 
 	labelNameAndValues, err := uniqueLabelNameAndValues(ctx, c.prometheusClient,
-		time.Now().Add(-1*c.lookbackInterval), time.Now(), selection)
+		time.Now().Add(-1*c.lookbackInterval), time.Now(), currLabelsSelected)
 	if err != nil {
 		return nil, err
 	}
@@ -73,15 +73,15 @@ func (c *compatibleHTTPClient) LabelNames(
 func (c *compatibleHTTPClient) LabelValues(
 	ctx context.Context,
 	label string,
-	selection model.LabelSet,
+	currLabelsSelected model.LabelSet,
 ) ([]model.LabelValue, error) {
-	if selection == nil {
+	if currLabelsSelected == nil {
 		values, _, err := c.prometheusClient.LabelValues(ctx, label, time.Now().Add(-1*c.lookbackInterval), time.Now())
 		return values, err
 	}
 
 	labelNameAndValues, err := uniqueLabelNameAndValues(ctx, c.prometheusClient,
-		time.Now().Add(-1*c.lookbackInterval), time.Now(), selection)
+		time.Now().Add(-1*c.lookbackInterval), time.Now(), currLabelsSelected)
 	if err != nil {
 		return nil, err
 	}

--- a/prometheus/empty.go
+++ b/prometheus/empty.go
@@ -34,11 +34,11 @@ func (c *emptyHTTPClient) AllMetricMetadata(_ context.Context) (map[string][]v1.
 	return make(map[string][]v1.Metadata), nil
 }
 
-func (c *emptyHTTPClient) LabelNames(_ context.Context, _ string) ([]string, error) {
+func (c *emptyHTTPClient) LabelNames(_ context.Context, _ model.LabelSet) ([]string, error) {
 	return []string{}, nil
 }
 
-func (c *emptyHTTPClient) LabelValues(_ context.Context, _ string) ([]model.LabelValue, error) {
+func (c *emptyHTTPClient) LabelValues(_ context.Context, _ string, _ model.LabelSet) ([]model.LabelValue, error) {
 	return []model.LabelValue{}, nil
 }
 

--- a/prometheus/metadata_service.go
+++ b/prometheus/metadata_service.go
@@ -92,10 +92,13 @@ type MetadataService interface {
 	// AllMetricMetadata returns metadata about metrics currently scraped for all existing metrics.
 	AllMetricMetadata(ctx context.Context) (map[string][]v1.Metadata, error)
 	// LabelNames returns all the unique label names present in the block in sorted order.
-	// If a metric is provided, then it will return all unique label names linked to the metric during a predefined period of time
-	LabelNames(ctx context.Context, selection model.LabelSet) ([]string, error)
+	// If currLabelsSelected is not nil, then it will return all unique label
+	// names that are relevant to the currently specified labels for a query.
+	LabelNames(ctx context.Context, currLabelsSelected model.LabelSet) ([]string, error)
 	// LabelValues performs a query for the values of the given label.
-	LabelValues(ctx context.Context, label string, selection model.LabelSet) ([]model.LabelValue, error)
+	// If currLabelsSelected is not nil, then it will return all unique label
+	// values that are relevant to the currently specified labels for a query.
+	LabelValues(ctx context.Context, label string, currLabelsSelected model.LabelSet) ([]model.LabelValue, error)
 	// ChangeDataSource is used if the prometheusURL is changing.
 	// The client should re init its own parameter accordingly if necessary
 	ChangeDataSource(prometheusURL string) error
@@ -141,16 +144,16 @@ func (c *httpClient) AllMetricMetadata(ctx context.Context) (map[string][]v1.Met
 	return c.subClient.AllMetricMetadata(ctx)
 }
 
-func (c *httpClient) LabelNames(ctx context.Context, selection model.LabelSet) ([]string, error) {
+func (c *httpClient) LabelNames(ctx context.Context, currLabelsSelected model.LabelSet) ([]string, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.subClient.LabelNames(ctx, selection)
+	return c.subClient.LabelNames(ctx, currLabelsSelected)
 }
 
-func (c *httpClient) LabelValues(ctx context.Context, label string, selection model.LabelSet) ([]model.LabelValue, error) {
+func (c *httpClient) LabelValues(ctx context.Context, label string, currLabelsSelected model.LabelSet) ([]model.LabelValue, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.subClient.LabelValues(ctx, label, selection)
+	return c.subClient.LabelValues(ctx, label, currLabelsSelected)
 }
 
 func (c *httpClient) GetURL() string {

--- a/prometheus/not_compatible.go
+++ b/prometheus/not_compatible.go
@@ -57,15 +57,15 @@ func (c *notCompatibleHTTPClient) AllMetricMetadata(ctx context.Context) (map[st
 
 func (c *notCompatibleHTTPClient) LabelNames(
 	ctx context.Context,
-	selection model.LabelSet,
+	currLabelsSelected model.LabelSet,
 ) ([]string, error) {
-	if selection == nil {
+	if currLabelsSelected == nil {
 		names, _, err := c.prometheusClient.LabelNames(ctx, time.Now().Add(-1*c.lookbackInterval), time.Now())
 		return names, err
 	}
 
 	labelNameAndValues, err := uniqueLabelNameAndValues(ctx, c.prometheusClient,
-		time.Now().Add(-1*c.lookbackInterval), time.Now(), selection)
+		time.Now().Add(-1*c.lookbackInterval), time.Now(), currLabelsSelected)
 	if err != nil {
 		return nil, err
 	}
@@ -81,15 +81,15 @@ func (c *notCompatibleHTTPClient) LabelNames(
 func (c *notCompatibleHTTPClient) LabelValues(
 	ctx context.Context,
 	label string,
-	selection model.LabelSet,
+	currLabelsSelected model.LabelSet,
 ) ([]model.LabelValue, error) {
-	if selection == nil {
+	if currLabelsSelected == nil {
 		values, _, err := c.prometheusClient.LabelValues(ctx, label, time.Now().Add(-1*c.lookbackInterval), time.Now())
 		return values, err
 	}
 
 	labelNameAndValues, err := uniqueLabelNameAndValues(ctx, c.prometheusClient,
-		time.Now().Add(-1*c.lookbackInterval), time.Now(), selection)
+		time.Now().Add(-1*c.lookbackInterval), time.Now(), currLabelsSelected)
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +124,11 @@ func uniqueLabelNameAndValues(
 	ctx context.Context,
 	prometheusClient v1.API,
 	start, end time.Time,
-	selection model.LabelSet,
+	currLabelsSelected model.LabelSet,
 ) (map[string]map[string]struct{}, error) {
 	metricName := ""
 	metricLabels := model.LabelSet{}
-	for k, v := range selection {
+	for k, v := range currLabelsSelected {
 		if k == model.MetricNameLabel {
 			metricName = string(v)
 		} else {


### PR DESCRIPTION
This adds the context to filter the label names and values down to the subset of timeseries applicable for a query. This also makes this logic applicable for filtering the label name suggestinos for a `by ()` statement in an aggregate expression.