### PR TITLE
fix(langserver): complete go.lsp.dev jsonrpc2/protocol migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0
+	go.uber.org/zap v1.28.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -41,7 +42,6 @@ require (
 	go.lsp.dev/uri v0.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.28.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/langserver/cache/document.go
+++ b/langserver/cache/document.go
@@ -22,8 +22,6 @@ import (
 
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
-
-	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/span"
 )
 
 // document caches content, metadata and compile results of a document.
@@ -78,15 +76,9 @@ func (d *DocumentHandle) ApplyIncrementalChanges(changes []protocol.TextDocument
 	uri := d.doc.uri
 
 	for _, change := range changes {
-		// Update column mapper along with the content.
-		converter := span.NewContentConverter(string(uri), content)
-		m := &protocol.ColumnMapper{
-			URI:       span.URI(d.doc.uri),
-			Converter: converter,
-			Content:   content,
-		}
-
-		spn, err := m.RangeSpan(change.Range)
+		// A fresh converter is built per change because content is mutated below,
+		// so the document's cached posData cannot be reused here.
+		spn, err := rangeToSpan(uri, content, change.Range)
 		if err != nil {
 			return "", err
 		}

--- a/langserver/cache/position.go
+++ b/langserver/cache/position.go
@@ -62,8 +62,8 @@ func (d *DocumentHandle) tokenPositionToProtocolPosition(pos token.Position) (pr
 		}
 
 		return protocol.Position{
-			Line:      uint32(line),
-			Character: uint32(char),
+			Line:      uint32(line), //nolint:gosec // G115: line numbers are bounded by document size and fit uint32.
+			Character: uint32(char), //nolint:gosec // G115: column numbers are bounded by document size and fit uint32.
 		}, nil
 	}
 }
@@ -160,4 +160,41 @@ func (d *DocumentHandle) tokenPosToTokenPosition(pos token.Pos) (token.Position,
 	default:
 		return d.doc.posData.Position(pos), nil
 	}
+}
+
+// rangeToSpan converts an LSP protocol.Range into a span.Span (byte offsets)
+// against the given content.
+//
+// It replaces the protocol.ColumnMapper.RangeSpan helper that the vendored
+// x/tools LSP package provided; go.lsp.dev/protocol is wire-only and has no
+// equivalent. The span package still supplies the UTF-16-to-byte-offset math.
+func rangeToSpan(uri protocol.DocumentURI, content []byte, r protocol.Range) (span.Span, error) {
+	converter := span.NewContentConverter(string(uri), content)
+
+	start, err := positionToPoint(converter, content, r.Start)
+	if err != nil {
+		return span.Span{}, err
+	}
+
+	end, err := positionToPoint(converter, content, r.End)
+	if err != nil {
+		return span.Span{}, err
+	}
+
+	return span.New(span.URI(uri), start, end).WithAll(converter)
+}
+
+// positionToPoint converts a zero-based LSP protocol.Position into a span.Point,
+// resolving the UTF-16 character offset against content.
+func positionToPoint(converter *span.TokenConverter, content []byte, p protocol.Position) (span.Point, error) {
+	line := int(p.Line) + 1
+
+	offset, err := converter.ToOffset(line, 1)
+	if err != nil {
+		return span.Point{}, err
+	}
+
+	lineStart := span.NewPoint(line, 1, offset)
+
+	return span.FromUTF16Column(lineStart, int(p.Character)+1, content)
 }

--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -316,7 +316,7 @@ func (s *server) completeLabel(ctx context.Context, completions *[]protocol.Comp
 	if err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: errors.Wrapf(err, "could not get label data from prometheus").Error(),
 		})
 		return err
@@ -359,7 +359,7 @@ func (s *server) completeLabelValue(ctx context.Context, completions *[]protocol
 	if err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: errors.Wrapf(err, "could not get label value data from Prometheus").Error(),
 		})
 		return err
@@ -444,7 +444,7 @@ func getEditRange(location *cache.Location, oldname string) (editRange protocol.
 		}
 	} else {
 		editRange.End = editRange.Start
-		editRange.End.Character += float64(len(oldname))
+		editRange.End.Character += uint32(len(oldname)) //nolint:gosec // G115: label length is bounded and fits uint32.
 	}
 
 	return editRange, err

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -43,7 +43,7 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 	s.client.LogMessage(
 		s.lifetime,
 		&protocol.LogMessageParams{
-			Type:    protocol.Info,
+			Type:    protocol.MessageTypeInfo,
 			Message: fmt.Sprintf("Received notification change: %v\n", params),
 		})
 
@@ -56,7 +56,7 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 	if marshallError != nil {
 		//nolint: errcheck
 		s.client.LogMessage(ctx, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: "unable to serialize the configuration",
 		})
 		return nil
@@ -64,7 +64,7 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 	if err := json.Unmarshal(rawData, &config); err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(ctx, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: errors.Wrap(err, "unexpected configuration format").Error(),
 		})
 		return nil
@@ -73,7 +73,7 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 	if err := s.setURLFromChangeConfiguration(config); err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(ctx, &protocol.LogMessageParams{
-			Type:    protocol.Info,
+			Type:    protocol.MessageTypeInfo,
 			Message: err.Error(),
 		})
 	}
@@ -81,7 +81,7 @@ func (s *server) DidChangeConfiguration(ctx context.Context, params *protocol.Di
 	if err := s.setMetadataLookbackInterval(config); err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(ctx, &protocol.LogMessageParams{
-			Type:    protocol.Info,
+			Type:    protocol.MessageTypeInfo,
 			Message: err.Error(),
 		})
 	}
@@ -102,7 +102,7 @@ func (s *server) connectPrometheus(url string) error {
 	if err := s.metadataService.ChangeDataSource(url); err != nil {
 		//nolint: errcheck
 		s.client.ShowMessage(s.lifetime, &protocol.ShowMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: fmt.Sprintf("Failed to connect to Prometheus at %s:\n\n%s ", url, err.Error()),
 		})
 		return err

--- a/langserver/diagnostics.go
+++ b/langserver/diagnostics.go
@@ -33,7 +33,7 @@ func (s *server) GetDiagnostics(uri protocol.DocumentURI) (*protocol.PublishDiag
 
 	reply := &protocol.PublishDiagnosticsParams{
 		URI:     uri,
-		Version: version,
+		Version: uint32(version), //nolint:gosec // G115: document version is non-negative and fits uint32.
 	}
 
 	diagnostics, err := d.GetDiagnostics()
@@ -51,7 +51,7 @@ func (s *server) diagnostics(uri protocol.DocumentURI) {
 	if err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: err.Error(),
 		})
 	}
@@ -59,13 +59,13 @@ func (s *server) diagnostics(uri protocol.DocumentURI) {
 	if err = s.client.PublishDiagnostics(s.lifetime, reply); err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: errors.Wrapf(err, "failed to publish diagnostics").Error(),
 		})
 	}
 }
 
-func (s *server) clearDiagnostics(ctx context.Context, uri protocol.DocumentURI, version float64) {
+func (s *server) clearDiagnostics(ctx context.Context, uri protocol.DocumentURI, version uint32) {
 	diagnostics := &protocol.PublishDiagnosticsParams{
 		URI:         uri,
 		Version:     version,
@@ -75,7 +75,7 @@ func (s *server) clearDiagnostics(ctx context.Context, uri protocol.DocumentURI,
 	if err := s.client.PublishDiagnostics(ctx, diagnostics); err != nil {
 		//nolint: errcheck
 		s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: errors.Wrapf(err, "failed to publish diagnostics").Error(),
 		})
 	}

--- a/langserver/general.go
+++ b/langserver/general.go
@@ -23,12 +23,12 @@ import (
 
 // Initialize handles a call from the client to initialize the server.
 // Required by the protocol.Server interface.
-func (s *server) Initialize(_ context.Context, _ *protocol.ParamInitialize) (*protocol.InitializeResult, error) {
+func (s *server) Initialize(_ context.Context, _ *protocol.InitializeParams) (*protocol.InitializeResult, error) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
 	if s.state != serverCreated {
-		return nil, jsonrpc2.NewErrorf(jsonrpc2.CodeInvalidRequest, "server already initialized")
+		return nil, jsonrpc2.Errorf(jsonrpc2.InvalidRequest, "server already initialized")
 	}
 
 	s.state = serverInitializing
@@ -43,12 +43,12 @@ func (s *server) Initialize(_ context.Context, _ *protocol.ParamInitialize) (*pr
 				Change: 2,
 			},
 			HoverProvider: true,
-			CompletionProvider: protocol.CompletionOptions{
+			CompletionProvider: &protocol.CompletionOptions{
 				TriggerCharacters: []string{
 					" ", "\n", "\t", "(", ")", "[", "]", "{", "}", "+", "-", "*", "/", "!", "=", "\"", ",", "'", "\"", "`", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "n", "m", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "N", "M", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
 				},
 			},
-			SignatureHelpProvider: protocol.SignatureHelpOptions{
+			SignatureHelpProvider: &protocol.SignatureHelpOptions{
 				TriggerCharacters: []string{"(", ","},
 			},
 			DefinitionProvider: true,
@@ -70,14 +70,14 @@ func (s *server) Initialized(ctx context.Context, _ *protocol.InitializedParams)
 		if err := s.connectPrometheus(s.prometheusURL); err != nil {
 			//nolint: errcheck
 			s.client.LogMessage(ctx, &protocol.LogMessageParams{
-				Type:    protocol.Info,
+				Type:    protocol.MessageTypeInfo,
 				Message: err.Error(),
 			})
 		}
 	} else {
 		//nolint: errcheck
 		s.client.LogMessage(ctx, &protocol.LogMessageParams{
-			Type:    protocol.Info,
+			Type:    protocol.MessageTypeInfo,
 			Message: "No Prometheus",
 		})
 	}
@@ -93,7 +93,7 @@ func (s *server) Shutdown(_ context.Context) error {
 	defer s.stateMu.Unlock()
 
 	if s.state != serverInitialized {
-		return jsonrpc2.NewErrorf(jsonrpc2.CodeInvalidRequest, "server not initialized")
+		return jsonrpc2.Errorf(jsonrpc2.InvalidRequest, "server not initialized")
 	}
 
 	s.state = serverShutDown
@@ -108,7 +108,7 @@ func (s *server) Exit(_ context.Context) error {
 	defer s.stateMu.Unlock()
 
 	if s.state != serverShutDown {
-		return jsonrpc2.NewErrorf(jsonrpc2.CodeInvalidRequest, "server not shutdown")
+		return jsonrpc2.Errorf(jsonrpc2.InvalidRequest, "server not shutdown")
 	}
 
 	s.exit()

--- a/langserver/headlessClient.go
+++ b/langserver/headlessClient.go
@@ -28,13 +28,13 @@ func (c *headlessClient) log(typ protocol.MessageType, msg string) error {
 	var logLevel func(log.Logger) log.Logger
 
 	switch typ {
-	case protocol.Error:
+	case protocol.MessageTypeError:
 		logLevel = level.Error
-	case protocol.Warning:
+	case protocol.MessageTypeWarning:
 		logLevel = level.Warn
-	case protocol.Info:
+	case protocol.MessageTypeInfo:
 		logLevel = level.Info
-	case protocol.Log:
+	case protocol.MessageTypeLog:
 		logLevel = level.Debug
 	default:
 		if err := level.Error(c.logger).Log("msg", "Message with unknown log level: "+msg); err != nil {
@@ -54,7 +54,7 @@ func (c *headlessClient) LogMessage(_ context.Context, params *protocol.LogMessa
 	return c.log(params.Type, params.Message)
 }
 
-func (*headlessClient) Event(_ context.Context, _ *interface{}) error {
+func (*headlessClient) Telemetry(_ context.Context, _ interface{}) error {
 	// ignore
 	return nil
 }
@@ -69,7 +69,7 @@ func (*headlessClient) WorkspaceFolders(_ context.Context) ([]protocol.Workspace
 	return nil, nil
 }
 
-func (*headlessClient) Configuration(_ context.Context, _ *protocol.ParamConfiguration) ([]interface{}, error) {
+func (*headlessClient) Configuration(_ context.Context, _ *protocol.ConfigurationParams) ([]interface{}, error) {
 	// ignore
 	return nil, nil
 }
@@ -89,9 +89,9 @@ func (*headlessClient) ShowMessageRequest(_ context.Context, _ *protocol.ShowMes
 	return nil, nil
 }
 
-func (*headlessClient) ApplyEdit(_ context.Context, _ *protocol.ApplyWorkspaceEditParams) (*protocol.ApplyWorkspaceEditResponse, error) {
+func (*headlessClient) ApplyEdit(_ context.Context, _ *protocol.ApplyWorkspaceEditParams) (bool, error) {
 	// ignore
-	return nil, nil
+	return false, nil
 }
 
 func (*headlessClient) Progress(_ context.Context, _ *protocol.ProgressParams) error {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -28,8 +28,7 @@ import (
 	"github.com/rakyll/statik/fs"
 	"go.lsp.dev/protocol"
 
-	"github.com/prometheus-community/promql-langserver/internal/vendored/go-tools/lsp/protocol"
-	"github.com/prometheus-community/promql-langserver/langserver/cache" //nolint:goimports
+	"github.com/prometheus-community/promql-langserver/langserver/cache"
 	// Do not remove! Side effects of init() needed.
 	_ "github.com/prometheus-community/promql-langserver/langserver/documentation/functions_statik"
 )
@@ -65,7 +64,7 @@ func (s *server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 			Kind:  "markdown",
 			Value: markdown,
 		},
-		Range: hoverRange,
+		Range: &hoverRange,
 	}, nil
 }
 
@@ -109,7 +108,7 @@ func (s *server) nodeToDocMarkdown(ctx context.Context, location *cache.Location
 			if err != nil {
 				//nolint: errcheck
 				s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-					Type:    protocol.Error,
+					Type:    protocol.MessageTypeError,
 					Message: errors.Wrapf(err, "failed to get recording rule data").Error(),
 				})
 			}
@@ -119,7 +118,7 @@ func (s *server) nodeToDocMarkdown(ctx context.Context, location *cache.Location
 				if err != nil {
 					//nolint: errcheck
 					s.client.LogMessage(s.lifetime, &protocol.LogMessageParams{
-						Type:    protocol.Error,
+						Type:    protocol.MessageTypeError,
 						Message: errors.Wrapf(err, "failed to get metric data").Error(),
 					})
 				}

--- a/langserver/jsonloggingstream.go
+++ b/langserver/jsonloggingstream.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"go.lsp.dev/jsonrpc2"
-	"go.lsp.dev/protocol"
 )
 
 type jsonLogStream struct {
@@ -33,55 +32,51 @@ type jsonLogStream struct {
 // jSONLogStream returns a stream that does log all communications in a format that
 // can be streamed into the LSP inspector.
 func jSONLogStream(str jsonrpc2.Stream, w io.Writer) jsonrpc2.Stream {
-	ret := &jsonLogStream{str, w}
-
-	return ret
+	return &jsonLogStream{str, w}
 }
 
-func (s *jsonLogStream) Read(ctx context.Context) ([]byte, int64, error) {
-	data, count, err := s.mainStream.Read(ctx)
-	s.log(data, true)
-
-	return data, count, err
-}
-
-func (s *jsonLogStream) Write(ctx context.Context, data []byte) (int64, error) {
-	count, err := s.mainStream.Write(ctx, data)
-	s.log(data, false)
-
-	return count, err
-}
-
-func getType(msg []byte, incoming bool) (string, error) {
-	var v protocol.Combined
-
-	var msgType string
-
-	err := json.Unmarshal(msg, &v)
-	if err != nil {
-		return "", err
+func (s *jsonLogStream) Read(ctx context.Context) (jsonrpc2.Message, int64, error) {
+	msg, count, err := s.mainStream.Read(ctx)
+	if err == nil {
+		s.log(msg, true)
 	}
 
+	return msg, count, err
+}
+
+func (s *jsonLogStream) Write(ctx context.Context, msg jsonrpc2.Message) (int64, error) {
+	s.log(msg, false)
+
+	return s.mainStream.Write(ctx, msg)
+}
+
+func (s *jsonLogStream) Close() error {
+	return s.mainStream.Close()
+}
+
+// messageType classifies a JSON-RPC message for the LSP inspector log.
+func messageType(msg jsonrpc2.Message, incoming bool) string {
+	direction := "receive-"
 	if incoming {
-		msgType = "send-"
-	} else {
-		msgType = "receive-"
+		direction = "send-"
 	}
 
-	switch {
-	case v.ID != nil && v.Method != "" && (v.Params != nil || v.Method == "shutdown"):
-		msgType += "request"
-	case v.ID != nil && v.Method == "" && v.Params == nil:
-		msgType += "response"
+	switch msg.(type) {
+	case *jsonrpc2.Call:
+		return direction + "request"
+	case *jsonrpc2.Response:
+		return direction + "response"
 	default:
-		msgType += "notification"
+		return direction + "notification"
 	}
-
-	return msgType, nil
 }
 
-func (s *jsonLogStream) log(msg []byte, incoming bool) {
-	typ, err := getType(msg, incoming)
+func (s *jsonLogStream) log(msg jsonrpc2.Message, incoming bool) {
+	if msg == nil {
+		return
+	}
+
+	data, err := json.Marshal(msg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -91,5 +86,5 @@ func (s *jsonLogStream) log(msg []byte, incoming bool) {
 	tmformat := time.Now().Format("03:04:15.000 PM")
 	// The LSP inspector expects the [LSP - <time>] part to be exactly 21 bytes
 	fmt.Fprintf(s.logWriter, `[LSP-%s] {"type":"%s","message":%s,"timestamp":%d}%s`,
-		tmformat, typ, msg, timestamp, " \r\n")
+		tmformat, messageType(msg, incoming), data, timestamp, " \r\n")
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -16,7 +16,9 @@ package langserver
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"go.lsp.dev/jsonrpc2"
@@ -33,230 +35,239 @@ func TestNotImplemented(*testing.T) { //nolint: gocognit, funlen, gocyclo
 	s := &server{}
 
 	err := s.DidChangeWorkspaceFolders(context.Background(), &protocol.DidChangeWorkspaceFoldersParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.DidSave(context.Background(), &protocol.DidSaveTextDocumentParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.WillSave(context.Background(), &protocol.WillSaveTextDocumentParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.DidChangeWatchedFiles(context.Background(), &protocol.DidChangeWatchedFilesParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	err = s.Progress(context.Background(), &protocol.ProgressParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	err = s.DidCreateFiles(context.Background(), &protocol.CreateFilesParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.SelectionRange(context.Background(), &protocol.SelectionRangeParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.Moniker(context.Background(), &protocol.MonikerParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	err = s.SetTraceNotification(context.Background(), &protocol.SetTraceParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	err = s.SetTrace(context.Background(), &protocol.SetTraceParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	err = s.LogTraceNotification(context.Background(), &protocol.LogTraceParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	err = s.LogTrace(context.Background(), &protocol.LogTraceParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Implementation(context.Background(), &protocol.ImplementationParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.TypeDefinition(context.Background(), &protocol.TypeDefinitionParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentColor(context.Background(), &protocol.DocumentColorParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ColorPresentation(context.Background(), &protocol.ColorPresentationParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.FoldingRange(context.Background(), &protocol.FoldingRangeParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.FoldingRanges(context.Background(), &protocol.FoldingRangeParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.NonstandardRequest(context.Background(), "", nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.Request(context.Background(), "", nil)
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Declaration(context.Background(), &protocol.DeclarationParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.WillSaveWaitUntil(context.Background(), &protocol.WillSaveTextDocumentParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.Resolve(context.Background(), &protocol.CompletionItem{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.CompletionResolve(context.Background(), &protocol.CompletionItem{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Definition(context.Background(), &protocol.DefinitionParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.References(context.Background(), &protocol.ReferenceParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentHighlight(context.Background(), &protocol.DocumentHighlightParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentSymbol(context.Background(), &protocol.DocumentSymbolParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.CodeAction(context.Background(), &protocol.CodeActionParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.Symbol(context.Background(), &protocol.WorkspaceSymbolParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.Symbols(context.Background(), &protocol.WorkspaceSymbolParams{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.CodeLens(context.Background(), &protocol.CodeLensParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.ResolveCodeLens(context.Background(), &protocol.CodeLens{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.CodeLensResolve(context.Background(), &protocol.CodeLens{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Formatting(context.Background(), &protocol.DocumentFormattingParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.RangeFormatting(context.Background(), &protocol.DocumentRangeFormattingParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.OnTypeFormatting(context.Background(), &protocol.DocumentOnTypeFormattingParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.Rename(context.Background(), &protocol.RenameParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.PrepareRename(context.Background(), &protocol.PrepareRenameParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.DocumentLink(context.Background(), &protocol.DocumentLinkParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.ResolveDocumentLink(context.Background(), &protocol.DocumentLink{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.DocumentLinkResolve(context.Background(), &protocol.DocumentLink{})
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{})
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.IncomingCalls(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.OutgoingCalls(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.PrepareCallHierarchy(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.SemanticTokens(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.SemanticTokensFull(context.Background(), nil)
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	_, err = s.SemanticTokensEdits(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	_, err = s.SemanticTokensFullDelta(context.Background(), nil)
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	_, err = s.SemanticTokensRange(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
 	err = s.WorkDoneProgressCancel(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 
-	err = s.WorkDoneProgressCreate(context.Background(), nil)
-	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.CodeMethodNotFound {
+	err = s.SemanticTokensRefresh(context.Background())
+	if err != nil && err.(*jsonrpc2.Error).Code != jsonrpc2.MethodNotFound {
 		panic("Expected a jsonrpc2 Error with CodeMethodNotFound")
 	}
 }
 
-// dummyStream is a fake jsonrpc2.Stream for Test purposes.
+// dummyStream is a fake jsonrpc2.Stream for test purposes. The tests drive the
+// server methods directly rather than over the wire, so Read only needs to
+// block until the connection is torn down (via context cancellation or Close).
 type dummyStream struct {
-	readQueue []byte
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
-func (d *dummyStream) Read(_ context.Context) ([]byte, int64, error) {
-	ret := d.readQueue
-	d.readQueue = []byte{}
-
-	return ret, int64(len(ret)), nil
+func newDummyStream() *dummyStream {
+	return &dummyStream{closed: make(chan struct{})}
 }
 
-func (d *dummyStream) Write(_ context.Context, text []byte) (int64, error) {
-	return int64(len(text)), nil
+func (d *dummyStream) Read(ctx context.Context) (jsonrpc2.Message, int64, error) {
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	case <-d.closed:
+		return nil, 0, io.EOF
+	}
 }
 
-// Push adds a text to the readQueue.
-func (d *dummyStream) Push(text []byte) {
-	d.readQueue = append(d.readQueue, text...)
+func (d *dummyStream) Write(_ context.Context, _ jsonrpc2.Message) (int64, error) {
+	return 0, nil
+}
+
+func (d *dummyStream) Close() error {
+	d.closeOnce.Do(func() { close(d.closed) })
+	return nil
 }
 
 type dummyWriter struct{}
@@ -267,18 +278,18 @@ func (d *dummyWriter) Write(text []byte) (int, error) {
 
 // TestServerState tries to emulate a full server lifetime.
 func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
-	var stream jsonrpc2.Stream = &dummyStream{}
+	var stream jsonrpc2.Stream = newDummyStream()
 	stream = jSONLogStream(stream, &dummyWriter{})
 	_, server := ServerFromStream(context.Background(), stream, &config.Config{LogFormat: config.TextFormat})
 	s := server.server
 
 	// Initialize Server
-	_, err := s.Initialize(context.Background(), &protocol.ParamInitialize{})
+	_, err := s.Initialize(context.Background(), &protocol.InitializeParams{})
 	if err != nil {
 		panic("Failed to initialize Server")
 	}
 
-	_, err = s.Initialize(context.Background(), &protocol.ParamInitialize{})
+	_, err = s.Initialize(context.Background(), &protocol.InitializeParams{})
 	if err == nil {
 		panic("cannot initialize server twice")
 	}
@@ -316,7 +327,6 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range:       nil,
 				RangeLength: 0,
 				Text:        "sum()",
 			},
@@ -356,7 +366,6 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range:       nil,
 				RangeLength: 0,
 				Text:        "metric_name",
 			},
@@ -395,7 +404,7 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range: &protocol.Range{
+				Range: protocol.Range{
 					Start: protocol.Position{
 						Line:      0.0,
 						Character: 0.0,
@@ -434,7 +443,7 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range: &protocol.Range{
+				Range: protocol.Range{
 					Start: protocol.Position{
 						Line:      0.0,
 						Character: 11.0,
@@ -484,7 +493,6 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range:       nil,
 				RangeLength: 0,
 				Text:        "rat",
 			},
@@ -521,7 +529,6 @@ func TestServer(t *testing.T) { //nolint:funlen, gocognit, gocyclo
 		},
 		ContentChanges: []protocol.TextDocumentContentChangeEvent{
 			{
-				Range:       nil,
 				RangeLength: 0,
 				Text:        "rat()",
 			},

--- a/langserver/notImplemented.go
+++ b/langserver/notImplemented.go
@@ -21,9 +21,65 @@ import (
 )
 
 func notImplemented(method string) *jsonrpc2.Error {
-	err := jsonrpc2.NewErrorf(jsonrpc2.CodeMethodNotFound, "method %q no yet implemented", method)
+	return jsonrpc2.Errorf(jsonrpc2.MethodNotFound, "method %q not yet implemented", method)
+}
 
-	return err
+// WorkDoneProgressCancel is required by the protocol.Server interface.
+func (s *server) WorkDoneProgressCancel(_ context.Context, _ *protocol.WorkDoneProgressCancelParams) error {
+	return notImplemented("WorkDoneProgressCancel")
+}
+
+// LogTrace is required by the protocol.Server interface.
+func (s *server) LogTrace(_ context.Context, _ *protocol.LogTraceParams) error {
+	return notImplemented("LogTrace")
+}
+
+// SetTrace is required by the protocol.Server interface.
+func (s *server) SetTrace(_ context.Context, _ *protocol.SetTraceParams) error {
+	return notImplemented("SetTrace")
+}
+
+// CodeAction is required by the protocol.Server interface.
+func (s *server) CodeAction(_ context.Context, _ *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
+	return nil, notImplemented("CodeAction")
+}
+
+// CodeLens is required by the protocol.Server interface.
+func (s *server) CodeLens(_ context.Context, _ *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
+	// The language client cannot be told to stop asking for Code Lenses, so to
+	// prevent the editor from showing error messages this is implemented by
+	// returning an empty result.
+	return nil, nil
+}
+
+// CodeLensResolve is required by the protocol.Server interface.
+func (s *server) CodeLensResolve(_ context.Context, _ *protocol.CodeLens) (*protocol.CodeLens, error) {
+	return nil, notImplemented("CodeLensResolve")
+}
+
+// CodeLensRefresh is required by the protocol.Server interface.
+func (s *server) CodeLensRefresh(_ context.Context) error {
+	return notImplemented("CodeLensRefresh")
+}
+
+// ColorPresentation is required by the protocol.Server interface.
+func (s *server) ColorPresentation(_ context.Context, _ *protocol.ColorPresentationParams) ([]protocol.ColorPresentation, error) {
+	return nil, notImplemented("ColorPresentation")
+}
+
+// CompletionResolve is required by the protocol.Server interface.
+func (s *server) CompletionResolve(_ context.Context, _ *protocol.CompletionItem) (*protocol.CompletionItem, error) {
+	return nil, notImplemented("CompletionResolve")
+}
+
+// Declaration is required by the protocol.Server interface.
+func (s *server) Declaration(_ context.Context, _ *protocol.DeclarationParams) ([]protocol.Location, error) {
+	return nil, notImplemented("Declaration")
+}
+
+// DidChangeWatchedFiles is required by the protocol.Server interface.
+func (s *server) DidChangeWatchedFiles(_ context.Context, _ *protocol.DidChangeWatchedFilesParams) error {
+	return notImplemented("DidChangeWatchedFiles")
 }
 
 // DidChangeWorkspaceFolders is required by the protocol.Server interface.
@@ -36,79 +92,9 @@ func (s *server) DidSave(_ context.Context, _ *protocol.DidSaveTextDocumentParam
 	return notImplemented("DidSave")
 }
 
-// WillSave is required by the protocol.Server interface.
-func (s *server) WillSave(_ context.Context, _ *protocol.WillSaveTextDocumentParams) error {
-	return notImplemented("WillSave")
-}
-
-// DidChangeWatchedFiles is required by the protocol.Server interface.
-func (s *server) DidChangeWatchedFiles(_ context.Context, _ *protocol.DidChangeWatchedFilesParams) error {
-	return notImplemented("DidChangeWatchedFiles")
-}
-
-// Progress is required by the protocol.Server interface.
-func (s *server) Progress(_ context.Context, _ *protocol.ProgressParams) error {
-	return notImplemented("Progress")
-}
-
-// SelectionRange is required by the protocol.Server interface.
-func (s *server) SelectionRange(_ context.Context, _ *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
-	return nil, notImplemented("SelectionRange")
-}
-
-// SetTraceNotification is required by the protocol.Server interface.
-func (s *server) SetTraceNotification(_ context.Context, _ *protocol.SetTraceParams) error {
-	return notImplemented("SetTraceNotification")
-}
-
-// LogTraceNotification is required by the protocol.Server interface.
-func (s *server) LogTraceNotification(_ context.Context, _ *protocol.LogTraceParams) error {
-	return notImplemented("LogTraceNotification")
-}
-
-// Implementation is required by the protocol.Server interface.
-func (s *server) Implementation(_ context.Context, _ *protocol.ImplementationParams) ([]protocol.Location, error) {
-	return nil, notImplemented("Implementation")
-}
-
-// TypeDefinition is required by the protocol.Server interface.
-func (s *server) TypeDefinition(_ context.Context, _ *protocol.TypeDefinitionParams) ([]protocol.Location, error) {
-	return nil, notImplemented("TypeDefinition")
-}
-
 // DocumentColor is required by the protocol.Server interface.
 func (s *server) DocumentColor(_ context.Context, _ *protocol.DocumentColorParams) ([]protocol.ColorInformation, error) {
 	return nil, notImplemented("DocumentColor")
-}
-
-// ColorPresentation is required by the protocol.Server interface.
-func (s *server) ColorPresentation(_ context.Context, _ *protocol.ColorPresentationParams) ([]protocol.ColorPresentation, error) {
-	return nil, notImplemented("ColorPresentation")
-}
-
-// FoldingRange is required by the protocol.Server interface.
-func (s *server) FoldingRange(_ context.Context, _ *protocol.FoldingRangeParams) ([]protocol.FoldingRange, error) {
-	return nil, notImplemented("FoldingRange")
-}
-
-// Declaration is required by the protocol.Server interface.
-func (s *server) Declaration(_ context.Context, _ *protocol.DeclarationParams) ([]protocol.Location, error) {
-	return nil, notImplemented("Declaration")
-}
-
-// WillSaveWaitUntil is required by the protocol.Server interface.
-func (s *server) WillSaveWaitUntil(_ context.Context, _ *protocol.WillSaveTextDocumentParams) ([]protocol.TextEdit, error) {
-	return nil, notImplemented("WillSaveWaitUntil")
-}
-
-// Resolve is required by the protocol.Server interface.
-func (s *server) Resolve(_ context.Context, _ *protocol.CompletionItem) (*protocol.CompletionItem, error) {
-	return nil, notImplemented("Resolve")
-}
-
-// References is required by the protocol.Server interface.
-func (s *server) References(_ context.Context, _ *protocol.ReferenceParams) ([]protocol.Location, error) {
-	return nil, notImplemented("References")
 }
 
 // DocumentHighlight is required by the protocol.Server interface.
@@ -116,43 +102,32 @@ func (s *server) DocumentHighlight(_ context.Context, _ *protocol.DocumentHighli
 	return nil, notImplemented("DocumentHighlight")
 }
 
+// DocumentLink is required by the protocol.Server interface.
+func (s *server) DocumentLink(_ context.Context, _ *protocol.DocumentLinkParams) ([]protocol.DocumentLink, error) {
+	// The language client cannot be told to stop asking for Document Links, so
+	// to prevent the editor from showing error messages this is implemented by
+	// returning an empty result.
+	return nil, nil
+}
+
+// DocumentLinkResolve is required by the protocol.Server interface.
+func (s *server) DocumentLinkResolve(_ context.Context, _ *protocol.DocumentLink) (*protocol.DocumentLink, error) {
+	return nil, notImplemented("DocumentLinkResolve")
+}
+
 // DocumentSymbol is required by the protocol.Server interface.
 func (s *server) DocumentSymbol(_ context.Context, _ *protocol.DocumentSymbolParams) ([]interface{}, error) {
 	return nil, notImplemented("DocumentSymbol")
 }
 
-// CodeAction is required by the protocol.Server interface.
-func (s *server) CodeAction(_ context.Context, _ *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
-	return nil, notImplemented("CodeAction")
+// ExecuteCommand is required by the protocol.Server interface.
+func (s *server) ExecuteCommand(_ context.Context, _ *protocol.ExecuteCommandParams) (interface{}, error) {
+	return nil, notImplemented("ExecuteCommand")
 }
 
-// NonstandardRequest is required by the protocol.Server interface.
-func (s *server) NonstandardRequest(_ context.Context, _ string, _ interface{}) (interface{}, error) {
-	return nil, notImplemented("NonstandardRequest")
-}
-
-// PrepareRename is required by the protocol.Server interface.
-func (s *server) PrepareRename(_ context.Context, _ *protocol.PrepareRenameParams) (*protocol.Range, error) {
-	return nil, notImplemented("PrepareRename")
-}
-
-// Symbol is required by the protocol.Server interface.
-func (s *server) Symbol(_ context.Context, _ *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
-	return nil, notImplemented("Symbol")
-}
-
-// CodeLens is required by the protocol.Server interface.
-func (s *server) CodeLens(_ context.Context, _ *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
-	// As of version 0.4.0 of gopls it is not possible to instruct the language
-	// client to stop asking for Code Lenses and Document Links. To prevent
-	// VS Code from showing error messages, this feature is implemented by
-	// returning empty values.
-	return nil, nil
-}
-
-// ResolveCodeLens is required by the protocol.Server interface.
-func (s *server) ResolveCodeLens(_ context.Context, _ *protocol.CodeLens) (*protocol.CodeLens, error) {
-	return nil, notImplemented("ResolveCodeLens")
+// FoldingRanges is required by the protocol.Server interface.
+func (s *server) FoldingRanges(_ context.Context, _ *protocol.FoldingRangeParams) ([]protocol.FoldingRange, error) {
+	return nil, notImplemented("FoldingRanges")
 }
 
 // Formatting is required by the protocol.Server interface.
@@ -160,9 +135,9 @@ func (s *server) Formatting(_ context.Context, _ *protocol.DocumentFormattingPar
 	return nil, notImplemented("Formatting")
 }
 
-// RangeFormatting is required by the protocol.Server interface.
-func (s *server) RangeFormatting(_ context.Context, _ *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
-	return nil, notImplemented("RangeFormatting")
+// Implementation is required by the protocol.Server interface.
+func (s *server) Implementation(_ context.Context, _ *protocol.ImplementationParams) ([]protocol.Location, error) {
+	return nil, notImplemented("Implementation")
 }
 
 // OnTypeFormatting is required by the protocol.Server interface.
@@ -170,28 +145,84 @@ func (s *server) OnTypeFormatting(_ context.Context, _ *protocol.DocumentOnTypeF
 	return nil, notImplemented("OnTypeFormatting")
 }
 
+// PrepareRename is required by the protocol.Server interface.
+func (s *server) PrepareRename(_ context.Context, _ *protocol.PrepareRenameParams) (*protocol.Range, error) {
+	return nil, notImplemented("PrepareRename")
+}
+
+// RangeFormatting is required by the protocol.Server interface.
+func (s *server) RangeFormatting(_ context.Context, _ *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
+	return nil, notImplemented("RangeFormatting")
+}
+
+// References is required by the protocol.Server interface.
+func (s *server) References(_ context.Context, _ *protocol.ReferenceParams) ([]protocol.Location, error) {
+	return nil, notImplemented("References")
+}
+
 // Rename is required by the protocol.Server interface.
 func (s *server) Rename(_ context.Context, _ *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
 	return nil, notImplemented("Rename")
 }
 
-// DocumentLink is required by the protocol.Server interface.
-func (s *server) DocumentLink(_ context.Context, _ *protocol.DocumentLinkParams) ([]protocol.DocumentLink, error) {
-	// As of version 0.4.0 of gopls it is not possible to instruct the language
-	// client to stop asking for Code Lenses and Document Links. To prevent
-	// VS Code from showing error messages, this feature is implemented by
-	// returning empty values.
-	return nil, nil
+// Symbols is required by the protocol.Server interface.
+func (s *server) Symbols(_ context.Context, _ *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	return nil, notImplemented("Symbols")
 }
 
-// ResolveDocumentLink is required by the protocol.Server interface.
-func (s *server) ResolveDocumentLink(_ context.Context, _ *protocol.DocumentLink) (*protocol.DocumentLink, error) {
-	return nil, notImplemented("ResolveDocumentLink")
+// TypeDefinition is required by the protocol.Server interface.
+func (s *server) TypeDefinition(_ context.Context, _ *protocol.TypeDefinitionParams) ([]protocol.Location, error) {
+	return nil, notImplemented("TypeDefinition")
 }
 
-// ExecuteCommand is required by the protocol.Server interface.
-func (s *server) ExecuteCommand(_ context.Context, _ *protocol.ExecuteCommandParams) (interface{}, error) {
-	return nil, notImplemented("ExecuteCommand")
+// WillSave is required by the protocol.Server interface.
+func (s *server) WillSave(_ context.Context, _ *protocol.WillSaveTextDocumentParams) error {
+	return notImplemented("WillSave")
+}
+
+// WillSaveWaitUntil is required by the protocol.Server interface.
+func (s *server) WillSaveWaitUntil(_ context.Context, _ *protocol.WillSaveTextDocumentParams) ([]protocol.TextEdit, error) {
+	return nil, notImplemented("WillSaveWaitUntil")
+}
+
+// ShowDocument is required by the protocol.Server interface.
+func (s *server) ShowDocument(_ context.Context, _ *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
+	return nil, notImplemented("ShowDocument")
+}
+
+// WillCreateFiles is required by the protocol.Server interface.
+func (s *server) WillCreateFiles(_ context.Context, _ *protocol.CreateFilesParams) (*protocol.WorkspaceEdit, error) {
+	return nil, notImplemented("WillCreateFiles")
+}
+
+// DidCreateFiles is required by the protocol.Server interface.
+func (s *server) DidCreateFiles(_ context.Context, _ *protocol.CreateFilesParams) error {
+	return notImplemented("DidCreateFiles")
+}
+
+// WillRenameFiles is required by the protocol.Server interface.
+func (s *server) WillRenameFiles(_ context.Context, _ *protocol.RenameFilesParams) (*protocol.WorkspaceEdit, error) {
+	return nil, notImplemented("WillRenameFiles")
+}
+
+// DidRenameFiles is required by the protocol.Server interface.
+func (s *server) DidRenameFiles(_ context.Context, _ *protocol.RenameFilesParams) error {
+	return notImplemented("DidRenameFiles")
+}
+
+// WillDeleteFiles is required by the protocol.Server interface.
+func (s *server) WillDeleteFiles(_ context.Context, _ *protocol.DeleteFilesParams) (*protocol.WorkspaceEdit, error) {
+	return nil, notImplemented("WillDeleteFiles")
+}
+
+// DidDeleteFiles is required by the protocol.Server interface.
+func (s *server) DidDeleteFiles(_ context.Context, _ *protocol.DeleteFilesParams) error {
+	return notImplemented("DidDeleteFiles")
+}
+
+// PrepareCallHierarchy is required by the protocol.Server interface.
+func (s *server) PrepareCallHierarchy(_ context.Context, _ *protocol.CallHierarchyPrepareParams) ([]protocol.CallHierarchyItem, error) {
+	return nil, notImplemented("PrepareCallHierarchy")
 }
 
 // IncomingCalls is required by the protocol.Server interface.
@@ -204,19 +235,14 @@ func (s *server) OutgoingCalls(_ context.Context, _ *protocol.CallHierarchyOutgo
 	return nil, notImplemented("OutgoingCalls")
 }
 
-// PrepareCallHierarchy is required by the protocol.Server interface.
-func (s *server) PrepareCallHierarchy(_ context.Context, _ *protocol.CallHierarchyPrepareParams) ([]protocol.CallHierarchyItem, error) {
-	return nil, notImplemented("PrepareCallHierarchy")
+// SemanticTokensFull is required by the protocol.Server interface.
+func (s *server) SemanticTokensFull(_ context.Context, _ *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {
+	return nil, notImplemented("SemanticTokensFull")
 }
 
-// SemanticTokens is required by the protocol.Server interface.
-func (s *server) SemanticTokens(_ context.Context, _ *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {
-	return nil, notImplemented("SemanticTokens")
-}
-
-// SemanticTokensEdits is required by the protocol.Server interface.
-func (s *server) SemanticTokensEdits(_ context.Context, _ *protocol.SemanticTokensEditsParams) (interface{}, error) {
-	return nil, notImplemented("SemanticTokensEdits")
+// SemanticTokensFullDelta is required by the protocol.Server interface.
+func (s *server) SemanticTokensFullDelta(_ context.Context, _ *protocol.SemanticTokensDeltaParams) (interface{}, error) {
+	return nil, notImplemented("SemanticTokensFullDelta")
 }
 
 // SemanticTokensRange is required by the protocol.Server interface.
@@ -224,12 +250,22 @@ func (s *server) SemanticTokensRange(_ context.Context, _ *protocol.SemanticToke
 	return nil, notImplemented("SemanticTokensRange")
 }
 
-// WorkDoneProgressCancel is required by the protocol.Server interface.
-func (s *server) WorkDoneProgressCancel(_ context.Context, _ *protocol.WorkDoneProgressCancelParams) error {
-	return notImplemented("WorkDoneProgressCancel")
+// SemanticTokensRefresh is required by the protocol.Server interface.
+func (s *server) SemanticTokensRefresh(_ context.Context) error {
+	return notImplemented("SemanticTokensRefresh")
 }
 
-// WorkDoneProgressCreate is required by the protocol.Server interface.
-func (s *server) WorkDoneProgressCreate(_ context.Context, _ *protocol.WorkDoneProgressCreateParams) error {
-	return notImplemented("WorkDoneProgressCreate")
+// LinkedEditingRange is required by the protocol.Server interface.
+func (s *server) LinkedEditingRange(_ context.Context, _ *protocol.LinkedEditingRangeParams) (*protocol.LinkedEditingRanges, error) {
+	return nil, notImplemented("LinkedEditingRange")
+}
+
+// Moniker is required by the protocol.Server interface.
+func (s *server) Moniker(_ context.Context, _ *protocol.MonikerParams) ([]protocol.Moniker, error) {
+	return nil, notImplemented("Moniker")
+}
+
+// Request is required by the protocol.Server interface.
+func (s *server) Request(_ context.Context, _ string, _ interface{}) (interface{}, error) {
+	return nil, notImplemented("Request")
 }

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-kit/log"
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
+	"go.uber.org/zap"
 
 	"github.com/prometheus-community/promql-langserver/config"
 	"github.com/prometheus-community/promql-langserver/langserver/cache"
@@ -51,7 +52,7 @@ type HeadlessServer interface {
 
 // server is a language server instance that can connect to exactly one client.
 type server struct {
-	Conn   *jsonrpc2.Conn
+	Conn   jsonrpc2.Conn
 	client protocol.Client
 
 	state   serverState
@@ -80,8 +81,12 @@ const (
 )
 
 // Run starts the language server instance.
+//
+// The connection is already serving (started in ServerFromStream via Conn.Go);
+// Run blocks until it is closed and reports the terminating error.
 func (s Server) Run() error {
-	return s.server.Conn.Run(s.server.lifetime)
+	<-s.server.Conn.Done()
+	return s.server.Conn.Err()
 }
 
 // CreateHeadlessServer creates a locked down server instance for the REST API.
@@ -96,7 +101,7 @@ func CreateHeadlessServer(ctx context.Context, metadataService promClient.Metada
 
 	s.lifetime, s.exit = context.WithCancel(ctx)
 
-	if _, err := s.Initialize(ctx, &protocol.ParamInitialize{}); err != nil {
+	if _, err := s.Initialize(ctx, &protocol.InitializeParams{}); err != nil {
 		return nil, err
 	}
 
@@ -121,7 +126,7 @@ func ServerFromStream(ctx context.Context, stream jsonrpc2.Stream, conf *config.
 			err := fmt.Errorf("invalid log format: '%s'", conf.LogFormat)
 			//nolint: errcheck
 			s.client.ShowMessage(s.lifetime, &protocol.ShowMessageParams{
-				Type:    protocol.Error,
+				Type:    protocol.MessageTypeError,
 				Message: err.Error(),
 			})
 			panic(err)
@@ -129,11 +134,13 @@ func ServerFromStream(ctx context.Context, stream jsonrpc2.Stream, conf *config.
 	}
 
 	s.Conn = jsonrpc2.NewConn(stream)
-	s.client = protocol.ClientDispatcher(s.Conn)
-
-	s.Conn.AddHandler(protocol.ServerHandler(s))
+	s.client = protocol.ClientDispatcher(s.Conn, zap.NewNop())
 
 	s.lifetime, s.exit = context.WithCancel(ctx)
+
+	// Go starts the asynchronous read loop; Server.Run waits on Conn.Done.
+	// Unhandled methods fall through to MethodNotFoundHandler.
+	s.Conn.Go(s.lifetime, protocol.ServerHandler(s, jsonrpc2.MethodNotFoundHandler))
 
 	// In order to have an error message in the IDE/editor, we are going to set the prometheusURL in the method server#Initialized.
 	s.prometheusURL = conf.PrometheusURL
@@ -141,7 +148,7 @@ func ServerFromStream(ctx context.Context, stream jsonrpc2.Stream, conf *config.
 	if err != nil {
 		//nolint: errcheck
 		s.client.ShowMessage(s.lifetime, &protocol.ShowMessageParams{
-			Type:    protocol.Error,
+			Type:    protocol.MessageTypeError,
 			Message: fmt.Sprintf("Failed to inialized the prometheus client\n\n%s ", err.Error()),
 		})
 		panic(err)
@@ -165,12 +172,28 @@ func RunTCPServer(ctx context.Context, addr string, conf *config.Config) error {
 			return err
 		}
 
-		go ServerFromStream(ctx, jsonrpc2.NewHeaderStream(conn, conn), conf)
+		go ServerFromStream(ctx, jsonrpc2.NewStream(conn), conf)
 	}
+}
+
+// stdio adapts os.Stdin and os.Stdout into a single io.ReadWriteCloser.
+//
+// go.lsp.dev/jsonrpc2.NewStream takes one connection, unlike the previous
+// jsonrpc2.NewHeaderStream which accepted a separate reader and writer.
+type stdio struct{}
+
+func (stdio) Read(p []byte) (int, error)  { return os.Stdin.Read(p) }
+func (stdio) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+
+func (stdio) Close() error {
+	if err := os.Stdin.Close(); err != nil {
+		return err
+	}
+	return os.Stdout.Close()
 }
 
 // StdioServer generates a Server instance talking to stdio.
 func StdioServer(ctx context.Context, conf *config.Config) (context.Context, Server) {
-	stream := jsonrpc2.NewHeaderStream(os.Stdin, os.Stdout)
+	stream := jsonrpc2.NewStream(stdio{})
 	return ServerFromStream(ctx, stream, conf)
 }

--- a/langserver/signature.go
+++ b/langserver/signature.go
@@ -50,11 +50,11 @@ func (s *server) SignatureHelp(ctx context.Context, params *protocol.SignatureHe
 		return nil, nil
 	}
 
-	activeParameter := 0.
+	var activeParameter uint32
 
 	for i, arg := range call.Args {
 		if arg != nil && arg.PositionRange().End < posrange.Pos(location.Pos-location.Query.Pos) {
-			activeParameter = float64(i) + 1
+			activeParameter = uint32(i) + 1
 		}
 	}
 

--- a/langserver/textSync.go
+++ b/langserver/textSync.go
@@ -52,7 +52,7 @@ func (s *server) DidClose(_ context.Context, params *protocol.DidCloseTextDocume
 func (s *server) DidChange(ctx context.Context, params *protocol.DidChangeTextDocumentParams) error {
 	// options := s.session.Options()
 	if len(params.ContentChanges) < 1 {
-		return jsonrpc2.NewErrorf(jsonrpc2.CodeInternalError, "no content changes provided")
+		return jsonrpc2.Errorf(jsonrpc2.InternalError, "no content changes provided")
 	}
 
 	uri := params.TextDocument.URI
@@ -91,7 +91,9 @@ func fullChange(changes []protocol.TextDocumentContentChangeEvent) (string, bool
 		return "", false
 	}
 	// The length of the changes must be 1 at this point.
-	if changes[0].Range == nil && changes[0].RangeLength == 0 {
+	// go.lsp.dev/protocol models Range as a value, so a full-document change
+	// (no range) arrives as the zero Range rather than a nil pointer.
+	if changes[0].Range == (protocol.Range{}) && changes[0].RangeLength == 0 {
 		return changes[0].Text, true
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -67,8 +67,8 @@ func (d *lspData) position() (protocol.Position, error) {
 		return protocol.Position{}, errors.New("positionChar is not specified")
 	}
 	return protocol.Position{
-		Line:      *d.PositionLine,
-		Character: *d.PositionChar,
+		Line:      uint32(*d.PositionLine),
+		Character: uint32(*d.PositionChar),
 	}, nil
 }
 


### PR DESCRIPTION
Follow-up to your `ColumnMapper` question on #312. This carries the migration the rest of the way.

`ColumnMapper` was the first error, but with `cache` fixed the rest of `langserver` surfaces: `go.lsp.dev`'s jsonrpc2 and protocol APIs differ from x/tools (interface `Conn` with `Go`/`Done`, bigger and renamed `Server`/`Client`, `uint32` positions), plus a few `float64` conversions and a duplicate import.

Green locally: build (including the crossbuild targets), `go test -race`, `golangci-lint`, and a live stdio `initialize` round-trip.

Targeting your branch so it folds into #312. Squash or cherry-pick, whatever's cleanest for you.
